### PR TITLE
#28129 #28217 #28218 #28219 Improvements to quicktime generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1022,10 +1022,17 @@ class FlameExport(Application):
                                                                     sg_data, 
                                                                     info["aspectRatio"])     
             
-            # and generate a quicktime
-            self._sg_submit_helper.upload_quicktime(sg_version_data["id"], 
-                                                    full_flame_plate_path, 
-                                                    info["width"], 
-                                                    info["height"])
+            export_preset_obj = self.export_preset_handler.get_preset_by_name(export_preset)
+            if export_preset_obj.upload_quicktime():
+                
+                # and upload a quicktime to shotgun
+                self._sg_submit_helper.upload_quicktime(sg_version_data["id"], 
+                                                        full_flame_plate_path, 
+                                                        info["width"], 
+                                                        info["height"])
+            else:
+                # don't upload quicktimes - instead upload a thumbnail
+                version_info = {"version_id": sg_data["id"], "path": full_flame_plate_path}
+                self._sg_submit_helper.upload_version_thumbnails([version_info])
 
 

--- a/app.py
+++ b/app.py
@@ -599,10 +599,10 @@ class FlameExport(Application):
                 if shot_metadata.has_batch_export():
                     # there is a batch publish associated with this segment! Add a publish request
                     sg_publishes.append({"type": "batch",
-                                          "path": segment_metadata.get_batch_path(),
+                                          "path": shot_metadata.get_batch_path(),
                                           "comments": self._user_comments,
                                           "serialized_context": sgtk.context.serialize(shot_metadata.context),
-                                          "version": segment_metadata.get_batch_version_number() })
+                                          "version": shot_metadata.get_batch_version_number() })
                                 
                 for segment_metadata in shot_metadata.segment_metadata.values():
 
@@ -659,7 +659,7 @@ class FlameExport(Application):
         #           push thumbnails for versions.
         #                 
                 
-        if self._export_preset.upload_quicktime() == False or self._app.get_setting("bypass_shotgun_transcoding"):
+        if self._export_preset.upload_quicktime() == False or self.get_setting("bypass_shotgun_transcoding"):
         
             # Create a single backburner job to handle this.
             job_title = "Shotgun Thumbnails"
@@ -1134,7 +1134,7 @@ class FlameExport(Application):
                                                                     info["aspectRatio"])     
             
             # step 2 - See if we should push a thumbnail
-            if export_preset_obj.upload_quicktime() == False or self._app.get_setting("bypass_shotgun_transcoding"):            
+            if export_preset_obj.upload_quicktime() == False or self.get_setting("bypass_shotgun_transcoding"):            
                 # there will be no transcoding happening on the server so pass a manual thumbnail
                 version_info = {"version_id": sg_data["id"], "path": full_flame_plate_path}
                 self._sg_submit_helper.upload_version_thumbnails([version_info])                

--- a/app.py
+++ b/app.py
@@ -118,6 +118,8 @@ class FlameExport(Application):
                      - abort: Pass True back to Flame if you want to abort
                      - abortMessage: Abort message to feed back to client
         """
+        # Note - Since Flame is a PySide only environment, we import it directly
+        # rather than going through the sgtk wrappers.         
         from PySide import QtGui
         
         # reset export session data
@@ -174,6 +176,8 @@ class FlameExport(Application):
                      - abortMessage: Error message to be displayed to the user when the export sequence
                        process has been aborted.
         """
+        # Note - Since Flame is a PySide only environment, we import it directly
+        # rather than going through the sgtk wrappers.         
         from PySide import QtGui
         sequence_name = info["sequenceName"]
         shot_names = info["shotNames"]
@@ -260,6 +264,8 @@ class FlameExport(Application):
         
         # first check that the clip has a shot name - otherwise things won't work!
         if shot_name == "":
+            # Note - Since Flame is a PySide only environment, we import it directly
+            # rather than going through the sgtk wrappers.             
             from PySide import QtGui
             QtGui.QMessageBox.warning(None,
                                       "Missing shot name!",
@@ -893,6 +899,8 @@ class FlameExport(Application):
         self._batch_context = context
 
         # ok so this looks like one of our renders - check with the user if they want to submit to review!
+        # Note - Since Flame is a PySide only environment, we import it directly
+        # rather than going through the sgtk wrappers.         
         from PySide import QtGui
          
         # pop up a UI asking the user for description

--- a/app.py
+++ b/app.py
@@ -631,6 +631,8 @@ class FlameExport(Application):
                             quicktime_path = self._export_preset.quicktime_path_from_render_path(render_path)
                         
                         sg_publishes.append({"type": "video",
+                                              "width": segment_metadata.video_info.get("width"),
+                                              "height": segment_metadata.video_info.get("height"),
                                               "path": segment_metadata.get_render_path(),
                                               "quicktime_path": quicktime_path,
                                               "comments": self._user_comments,
@@ -673,6 +675,8 @@ class FlameExport(Application):
                         if segment_metadata.has_shotgun_version():
                             # this segment has video and has a version!
                             item = {"path": segment_metadata.get_render_path(), 
+                                    "width": segment_metadata.video_info.get("width"),
+                                    "height": segment_metadata.video_info.get("height"),
                                     "version_id": segment_metadata.get_shotgun_version_id()}
                             items.append(item)
             
@@ -984,6 +988,8 @@ class FlameExport(Application):
           "version": 123}
                                             
         { "type": "video",
+          "width": 1234,
+          "height": 1234,
           "path": "/foo/bar",
           "quicktime_path": "/path/to/quicktime.mov" # optional, may be None
           "comments": "Some user comments",
@@ -1011,6 +1017,8 @@ class FlameExport(Application):
             elif request["type"] == "video":
                 sg_data = self._sg_submit_helper.register_video_publish(export_preset,
                                                                         context,
+                                                                        request["width"], 
+                                                                        request["height"],                                                                        
                                                                         request["path"], 
                                                                         request["quicktime_path"],
                                                                         request["comments"], 
@@ -1051,7 +1059,7 @@ class FlameExport(Application):
         """
         Backburner job. Upload thumbnails for a list of versions.
         
-        Each version is represented by a dictionary with keys path and version_id, 
+        Each version is represented by a dictionary with keys path, width, height and version_id, 
         where the path is a path to an exported flame item 
         
         :param items: List of dictionaries. See above
@@ -1124,6 +1132,8 @@ class FlameExport(Application):
         
         sg_data = self._sg_submit_helper.register_video_publish(export_preset,
                                                                 context, 
+                                                                info["width"], 
+                                                                info["height"],                                                                
                                                                 full_flame_plate_path, 
                                                                 quicktime_path,
                                                                 description,
@@ -1144,7 +1154,10 @@ class FlameExport(Application):
             # step 2 - See if we should push a thumbnail
             if export_preset_obj.upload_quicktime() == False or self.get_setting("bypass_shotgun_transcoding"):            
                 # there will be no transcoding happening on the server so pass a manual thumbnail
-                version_info = {"version_id": sg_version_data["id"], "path": full_flame_plate_path}
+                version_info = {"version_id": sg_version_data["id"], 
+                                "width": info["width"],
+                                "height": info["height"],
+                                "path": full_flame_plate_path}
                 self._sg_submit_helper.upload_version_thumbnails([version_info])                
                 
             # Step 3 - Generate and upload quicktime

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@
 """
 Flame Shot Exporter.
 
-This app takes a sequence in flame and generates lots of Shotgun related content.
+This app takes a sequence in Flame and generates lots of Shotgun related content.
 It is similar to the Hiero exporter. The following items are generated:
 
 - New Shots in Shotgun, with tasks
@@ -21,16 +21,16 @@ It is similar to the Hiero exporter. The following items are generated:
 - Batch files for each shot
 - Clip xml files for shots and clips.
 
-The exporter is effectively a wrapper around the flame custom export process 
+The exporter is effectively a wrapper around the Flame custom export process 
 with some bindings to Shotgun.
 
 This app implements two different sets of callbacks - both utilizing the same 
 configuration and essentially parts of the same workflow (this is why they are not
 split across two different apps).
 
-- The flame Shot export runs via a context menu item on the sequence right-click menu
-- A flare / batch mode render hook allows Shotgun to intercept the rendering process and
-  ask the user if they want to submit to shotgun review whenever they render out in flame. 
+- The Flame Shot export runs via a context menu item on the sequence right-click menu
+- A Flare / batch mode render hook allows Shotgun to intercept the rendering process and
+  ask the user if they want to submit to Shotgun review whenever they render out in Flame. 
 
 """
 
@@ -83,7 +83,7 @@ class FlameExport(Application):
         # this wrapper class is used later on to access export presets in various ways
         self.export_preset_handler = tk_flame_export_no_ui.ExportPresetHandler()
         
-        # register our desired interaction with flame hooks
+        # register our desired interaction with Flame hooks
         # set up callbacks for the engine to trigger 
         # when this profile is being triggered
         menu_caption = self.get_setting("menu_name")        
@@ -95,7 +95,7 @@ class FlameExport(Application):
         callbacks["postCustomExport"] = self.do_submission_and_summary
         self.engine.register_export_hook(menu_caption, callbacks)
         
-        # also register this app so that it runs after export in batch mode / flare
+        # also register this app so that it runs after export in batch mode / Flare
         batch_callbacks = {}
         batch_callbacks["batchExportEnd"] = self.post_batch_render_sg_process
         batch_callbacks["batchExportBegin"] = self.pre_batch_render_checks
@@ -107,7 +107,7 @@ class FlameExport(Application):
 
     def pre_custom_export(self, session_id, info):
         """
-        Hook called before a custom export begins. The export will be blocked
+        Flame hook called before a custom export begins. The export will be blocked
         until this function returns. This can be used to fill information that would
         have normally been extracted from the export window.
         
@@ -115,7 +115,7 @@ class FlameExport(Application):
                      - destinationHost: Host name where the exported files will be written to.
                      - destinationPath: Export path root.
                      - presetPath: Path to the preset used for the export.
-                     - abort: Pass True back to flame if you want to abort
+                     - abort: Pass True back to Flame if you want to abort
                      - abortMessage: Abort message to feed back to client
         """
         from PySide import QtGui
@@ -157,7 +157,7 @@ class FlameExport(Application):
                 
     def pre_export_sequence(self, session_id, info):
         """
-        Called from the flame hooks before export.
+        Called from the Flame hooks before export.
         This is the time to set up the structure in Shotgun.
         
         :param session_id: String which identifies which export session is being referred to
@@ -167,12 +167,12 @@ class FlameExport(Application):
                      - destinationPath: Export path root.
                      - sequenceName: Name of the exported sequence.
                      - shotNames: Tuple of all shot names in the exported sequence. 
-                                  Multiple segments could have the same shot name.
+                       Multiple segments could have the same shot name.
                      - abort: Hook can set this to True if the export sequence process should
-                              be aborted. If other sequences are exported in the same export session
-                              they will still be exported even if this export sequence is aborted.
+                       be aborted. If other sequences are exported in the same export session
+                       they will still be exported even if this export sequence is aborted.
                      - abortMessage: Error message to be displayed to the user when the export sequence
-                                     process has been aborted.
+                       process has been aborted.
         """
         from PySide import QtGui
         sequence_name = info["sequenceName"]
@@ -199,7 +199,7 @@ class FlameExport(Application):
             return
 
         # process a sequence and some shots:
-        # create entities in shotgun, create folders on disk and compute shot contexts.
+        # create entities in Shotgun, create folders on disk and compute shot contexts.
         sequence_data = self._sg_submit_helper.create_shotgun_structure(sequence_name, shot_names)
         
         # add it to the full dictionary of things to export
@@ -208,10 +208,10 @@ class FlameExport(Application):
     
     def pre_export_asset(self, session_id, info):
         """
-        Called when an item is about to be exported and a path needs to be computed.
+        Flame hook called when an item is about to be exported and a path needs to be computed.
         
-        This will take the parameters from flame, push them through the toolkit template
-        system and then return a path to flame that flame will be using for the export.
+        This will take the parameters from Flame, push them through the toolkit template
+        system and then return a path to Flame that Flame will be using for the export.
  
         :param session_id: String which identifies which export session is being referred to.
                            This parameter makes it possible to distinguish between different 
@@ -306,7 +306,7 @@ class FlameExport(Application):
         self.log_debug("Resolved context based fields: %s" % fields)
         
         if asset_type == "video":
-            # handle the flame sequence token - it will come in as "[1001-1100]"
+            # handle the Flame sequence token - it will come in as "[1001-1100]"
             re_match = re.search("(\[[0-9]+-[0-9]+\])\.", info["resolvedPath"])
             if not re_match:
                 raise TankError("Cannot find frame number token in export data!")
@@ -346,13 +346,13 @@ class FlameExport(Application):
         
         self.log_debug("Chopping off root path %s -> %s" % (full_path, local_path))
         
-        # pass an updated path back to the flame. This ensures that all the 
+        # pass an updated path back to the Flame. This ensures that all the 
         # character substitutions etc are handled according to the toolkit logic 
         info["resolvedPath"] = local_path        
         
     def post_export_asset(self, session_id, info):
         """
-        Called when an item has been exported.
+        Flame hook called when an item has been exported.
         
         :param session_id: String which identifies which export session is being referred to.
                            This parameter makes it possible to distinguish between different 
@@ -426,7 +426,7 @@ class FlameExport(Application):
 
     def do_submission_and_summary(self, session_id, info):
         """
-        Push info to Shotgun and display a summary UI.
+        Flame hook which will push info to Shotgun and display a summary UI.
         
         :param session_id: String which identifies which export session is being referred to.
                            This parameter makes it possible to distinguish between different 
@@ -454,7 +454,7 @@ class FlameExport(Application):
         #
         num_created_shots = 0
         for seq in self._shots:
-            # get a list of metadata objects for this shot
+            # get a list of metadata objects for this sequence
             shot_metadata_list = self._shots[seq].values()
             # sort it by cut in
             shot_metadata_list.sort(key=lambda x: x.new_cut_in)
@@ -472,12 +472,12 @@ class FlameExport(Application):
         #           This happens as a single Shotgun batch call.
         # 
         
-        # we push all changes to shotgun as a single batch call
+        # we push all changes to Shotgun as a single batch call
         shotgun_batch_items = []
         version_path_lookup = {}
                 
         # loop over all shots in our metadata data structure
-        self.log_debug("Looping over all shots and segments to submit shotgun data...")
+        self.log_debug("Looping over all shots and segments to submit Shotgun data...")
         num_cut_changes = 0
         for seq in self._shots:
             for shot_metadata in self._shots[seq].values():
@@ -497,7 +497,7 @@ class FlameExport(Application):
                     if segment_metadata.has_render_export():
                         
                         # we have a video submission associated with this segment!
-                        # compute a version-create shotgun batch dictionary
+                        # compute a version-create Shotgun batch dictionary
                         sg_version_batch = self._sg_submit_helper.create_version_batch(shot_metadata.context, 
                                                                                        segment_metadata.get_render_path(), 
                                                                                        self._user_comments, 
@@ -508,12 +508,12 @@ class FlameExport(Application):
                         shotgun_batch_items.append(sg_version_batch)
                         
                         # once the batch has been executed and the versions have been created in Shotgun,
-                        # we need to update our segment metadata with the shotgun version id.
+                        # we need to update our segment metadata with the Shotgun version id.
                         # in order to do that, maintain a lookup dictionary:
                         path_to_frames = sg_version_batch["data"]["sg_path_to_frames"]
                         version_path_lookup[path_to_frames] = segment_metadata
                 
-                # Now update frame ranges to make sure shotgun matches flame.
+                # Now update frame ranges to make sure Shotgun matches Flame.
                 #
                 # ensure that we actually have frame ranges for this shot
                 # it seems sometimes there are shots that don't actually contain any clips.
@@ -529,6 +529,10 @@ class FlameExport(Application):
                     
                     duration = shot_metadata.new_cut_out - shot_metadata.new_cut_in + 1
                     num_cut_changes += 1
+                    
+                    # note that at this point all shots are guaranteed to exist in Shotgun
+                    # since they were created in the initial export step.
+                    
                     sg_cut_batch = {"request_type":"update", 
                                     "entity_type": "Shot",
                                     "entity_id": shot_metadata.shotgun_id,
@@ -541,7 +545,7 @@ class FlameExport(Application):
                     shotgun_batch_items.append(sg_cut_batch)
                 
                 else:
-                    self.log_debug("No frame changes detected. Shotgun and flame are already in sync.")
+                    self.log_debug("No frame changes detected. Shotgun and Flame are already in sync.")
         
         # now push all new versions and cut changes to Shotgun in a single batch call.
         sg_data = []
@@ -558,7 +562,7 @@ class FlameExport(Application):
                 
         ##########################################################################################
         #
-        # Stage 3 - Update metadata with created shotgun version ids so we can access it later
+        # Stage 3 - Update metadata with created Shotgun version ids so we can access it later
         #                 
                 
         # now update the shot metadata with version ids
@@ -569,7 +573,7 @@ class FlameExport(Application):
                 segment_metadata.shotgun_version = sg_entity
         
         # also, find out the highest backburner ID so that we can create a dependency later on
-        # because the various flame exports may be running in backburner jobs, we need to figure out 
+        # because the various Flame exports may be running in backburner jobs, we need to figure out 
         # the last backburner job id and create a dependency from our jobs to this job. This is 
         # because stuff such as thumbnails etc are extracted as part of publishing and other jobs
         # and we cannot do that before the actual render export has completed.
@@ -693,19 +697,19 @@ class FlameExport(Application):
             
         ##########################################################################################
         #
-        # Stage 6 - For each segment, generate and upload a quicktime to shotgun.
+        # Stage 6 - For each segment, generate and upload a quicktime to Shotgun.
         #           Each item will be processed in a separate backburner job.
         #                 
         
         if self._export_preset.upload_quicktime():
             
-            # let's create quicktimes suitable for shotgun and upload these.
+            # let's create quicktimes suitable for Shotgun and upload these.
             # create one separate backburner job for each upload for parallelisation  
             for seq in self._shots:
                 for shot_metadata in self._shots[seq].values():
                     for segment_metadata in shot_metadata.segment_metadata.values():
                                                     
-                        if segment_metadata.has_shotgun_version():
+                        if segment_metadata.has_Shotgun_version():
                             # this segment has video and has a version!
                             # schedule quicktime generation!
                             
@@ -746,7 +750,7 @@ class FlameExport(Application):
         if self._export_preset.make_highres_quicktime():
             # let's create quicktimes suitable for local playback (for example in RV)
             # create one separate backburner job for each upload for parallelisation 
-            # this are pushed onto the queue after any shotgun transcoding jobs. 
+            # this are pushed onto the queue after any Shotgun transcoding jobs. 
             for seq in self._shots:
                 for shot_metadata in self._shots[seq].values():
                     for segment_metadata in shot_metadata.segment_metadata.values():
@@ -818,7 +822,7 @@ class FlameExport(Application):
 
     def pre_batch_render_checks(self, info):
         """
-        Called before rendering starts in batch/flare.
+        Flame hook called before rendering starts in batch/Flare.
         
         This pops up a UI asking the user if they want to send things to review.
         
@@ -851,7 +855,7 @@ class FlameExport(Application):
             width:                Frame width
             height:               Frame height
             depth:                Frame depth ( '8-bits', '10-bits', '12-bits', '16 fp' )
-            scanForamt:           Scan format ( 'FIELD_1', 'FIELD_2', 'PROGRESSIVE' )        
+            scanFormat:           Scan format ( 'FIELD_1', 'FIELD_2', 'PROGRESSIVE' )        
         """
         
         # these member variables are used to pass data down the pipeline, to post_batch_render_sg_process()
@@ -903,7 +907,7 @@ class FlameExport(Application):
 
     def post_batch_render_sg_process(self, info):
         """
-        Called when batch rendering has finished.
+        Flame hook called when batch rendering has finished.
         
         :param info: Dictionary with a number of parameters:
         
@@ -938,7 +942,7 @@ class FlameExport(Application):
             aborted:              Indicate if the export has been aborted by the user.
         """
         
-        if "aborted" in info and info["aborted"]:
+        if info.get("aborted"):
             self.log_debug("Rendering was aborted. Will not push to Shotgun.")
             return 
         
@@ -972,7 +976,7 @@ class FlameExport(Application):
 
 
     ##############################################################################################################
-    # backburner callbacks. These methods are executed as backburner jobs and not inside the main flame UI.
+    # backburner callbacks. These methods are executed as backburner jobs and not inside the main Flame UI.
     # at this point, there is no access to any UI.
 
     def backburner_register_publishes(self, publish_requests, export_preset):
@@ -1060,7 +1064,7 @@ class FlameExport(Application):
         Backburner job. Upload thumbnails for a list of versions.
         
         Each version is represented by a dictionary with keys path, width, height and version_id, 
-        where the path is a path to an exported flame item 
+        where the path is a path to an exported Flame item 
         
         :param items: List of dictionaries. See above
         """
@@ -1104,7 +1108,7 @@ class FlameExport(Application):
             width:                Frame width
             height:               Frame height
             depth:                Frame depth ( '8-bits', '10-bits', '12-bits', '16 fp' )
-            scanForamt:           Scan format ( 'FIELD_1', 'FIELD_2', 'PROGRESSIVE' ) 
+            scanFormat:           Scan format ( 'FIELD_1', 'FIELD_2', 'PROGRESSIVE' ) 
             
         :param export_preset: Export preset associated with this session
         :param serialized_context: The context for the shot that the submission 
@@ -1162,7 +1166,7 @@ class FlameExport(Application):
                 
             # Step 3 - Generate and upload quicktime
             if export_preset_obj.upload_quicktime():
-                # and upload a quicktime to shotgun
+                # and upload a quicktime to Shotgun
                 self._sg_submit_helper.upload_quicktime(sg_version_data["id"], 
                                                         full_flame_plate_path, 
                                                         info["width"], 

--- a/app.py
+++ b/app.py
@@ -171,11 +171,11 @@ class FlameExport(Application):
                      - abortMessage: Error message to be displayed to the user when the export sequence
                                      process has been aborted.
         """
+        from PySide import QtGui
         sequence_name = info["sequenceName"]
         shot_names = info["shotNames"]
         
         if len(shot_names) == 0:
-            from PySide import QtGui     
             QtGui.QMessageBox.warning(None,
                                       "Please name your shots!",
                                       "The Shotgun integration requires you to name your shots. Please go back to "
@@ -186,7 +186,6 @@ class FlameExport(Application):
             return
         
         if " " in sequence_name:
-            from PySide import QtGui     
             QtGui.QMessageBox.warning(None,
                                       "Sequence name cannot contain spaces!",
                                       "Your Sequence name contains spaces. This is currently not supported by "

--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -107,6 +107,18 @@ class ExportSettings(HookBaseClass):
         
         return xml
         
+    def get_external_ffmpeg_location(self):
+        """
+        Control which version of ffmpeg you want to use when doing transcoding.
+        By default, this hook returns None, indicating that the app should use
+        the built-in version of ffmpeg that comes with Flame.
+        
+        If you want to use a different version of ffmpeg, simply return the path
+        to the ffmpeg binary here. 
+        
+        :returns: path to ffmpeg as str, or None if the default should be used.
+        """
+        return None
         
     def get_ffmpeg_quicktime_encode_parameters(self):
         """

--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -151,7 +151,10 @@ class ExportSettings(HookBaseClass):
             
     def get_local_quicktime_preferred_height(self, width, height):
         """
-        Controll the preferred height of the local quicktime movie that is generated.
+        Control the preferred height of the local quicktime movie that is generated.
+        The quicktime generation will try to match this as closely as possible, but may
+        change it depending on technical constraints (for example, the aspect ratio needs to
+        be preserved exactly and width and height both need to be factors of 2.)
         
         :param width: The width in pixels of the input images 
         :param height: The height in pixels of the input images

--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -108,9 +108,6 @@ class ExportSettings(HookBaseClass):
         return xml
         
         
-
-
-
     def get_ffmpeg_quicktime_encode_parameters(self):
         """
         Control how quicktimes are generated before being uploaded to Shotgun.
@@ -151,4 +148,27 @@ class ExportSettings(HookBaseClass):
         params += "-crf 15 " 
         
         return params
-                
+            
+    def get_local_quicktime_preferred_height(self, width, height):
+        """
+        Controll the preferred height of the local quicktime movie that is generated.
+        
+        :param width: The width in pixels of the input images 
+        :param height: The height in pixels of the input images
+        :returns: The desired height.
+        """
+        return 1080
+
+    def get_local_quicktime_ffmpeg_encode_parameters(self):
+        """
+        Control how quicktimes are generated for local playback in tools such as RV.
+        
+        These quicktimes are generated inside flame using ffmpeg version SVN-r17733.
+        Note that the syntax has changed somewhat in more recent version of ffmpeg
+        and be careful to test that all parameters and traits you wish to customize
+        are included and supported in this particular build of ffmpeg.
+        
+        :returns: string of ffmpeg parameters which will be appended to the ffmpeg command line
+        """
+        # the default implementation uses the same preset as the shotgun upload
+        return self.get_ffmpeg_quicktime_encode_parameters()

--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -17,7 +17,7 @@ HookBaseClass = sgtk.get_hook_baseclass()
 
 class ExportSettings(HookBaseClass):
     """
-    This hook controls the settings that flame will use when it exports plates and generates 
+    This hook controls the settings that Flame will use when it exports plates and generates 
     quicktimes prior to uploading them to Shotgun.
     """
 
@@ -26,7 +26,7 @@ class ExportSettings(HookBaseClass):
         Returns a chunk of video xml export profile given a preset name.
         This chunk of XML will be joined into a larger structure which defines
         the entire set of export options. The app will then pass this full preset
-        to flame for file generation.
+        to Flame for file generation.
         
         The preset name should correspond to one of the presets defined in the app
         config - for each of these presets, this hook needs to implement logic to 
@@ -40,7 +40,7 @@ class ExportSettings(HookBaseClass):
         :param name_pattern: Data to inject into the <name_pattern> tag in the xml structure.
         :param publish_linked: Data to inject into the <publishLinked> tag in the xml structure.
         
-        :returns: the <video> xml section of a flame export.
+        :returns: the <video> xml section of a Flame export.
         """ 
         
         if preset_name == "10 bit DPX":
@@ -123,7 +123,7 @@ class ExportSettings(HookBaseClass):
     def get_ffmpeg_quicktime_encode_parameters(self):
         """
         Control how quicktimes are generated before being uploaded to Shotgun.
-        These quicktimes are generated inside flame using ffmpeg version SVN-r17733.
+        These quicktimes are generated inside Flame using ffmpeg version SVN-r17733.
         Note that the syntax has changed somewhat in more recent version of ffmpeg
         and be careful to test that all parameters and traits you wish to customize
         are included and supported in this particular build of ffmpeg.
@@ -179,7 +179,7 @@ class ExportSettings(HookBaseClass):
         """
         Control how quicktimes are generated for local playback in tools such as RV.
         
-        These quicktimes are generated inside flame using ffmpeg version SVN-r17733.
+        These quicktimes are generated inside Flame using ffmpeg version SVN-r17733.
         Note that the syntax has changed somewhat in more recent version of ffmpeg
         and be careful to test that all parameters and traits you wish to customize
         are included and supported in this particular build of ffmpeg.

--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -143,9 +143,10 @@ class ExportSettings(HookBaseClass):
         # sane range is 18-28. Consider 18 to be visually lossless or nearly so: it should 
         # look the same or nearly the same as the input but it isn't technically lossless."
         #
-        # Note: 15 is the highest quality preset available in the wiretap central export presets.
-        #
-        params += "-crf 20 " 
+        # Note: Quality setting 28 seems to generate roughly the same bit rates that you get  
+        #       with the 2kbit setting that Shotgun is using.
+        # 
+        params += "-crf 28 " 
         
         return params
             
@@ -199,4 +200,4 @@ class ExportSettings(HookBaseClass):
         #
         # Note: 15 is the highest quality preset available in the wiretap central export presets.
         #
-        params += "-crf 15 " 
+        params += "-crf 18 " 

--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -145,7 +145,7 @@ class ExportSettings(HookBaseClass):
         #
         # Note: 15 is the highest quality preset available in the wiretap central export presets.
         #
-        params += "-crf 15 " 
+        params += "-crf 20 " 
         
         return params
             
@@ -173,5 +173,30 @@ class ExportSettings(HookBaseClass):
         
         :returns: string of ffmpeg parameters which will be appended to the ffmpeg command line
         """
-        # the default implementation uses the same preset as the shotgun upload
-        return self.get_ffmpeg_quicktime_encode_parameters()
+        # the default hook implements the H264 (High) preset that is shipped with 
+        # the wiretap central subsystem. The following parameters have been extracted from
+        # the preset xml file. For detailed information about the meaning of any of these 
+        # parameters, see https://trac.ffmpeg.org/wiki/Encode/H.264
+        #
+        # NOTE! The version of ffmpeg that ships with wiretap central is FFmpeg version SVN-r17733
+        # from 2009 and its parameters do not seem to be compatible with modern versions of ffmpeg.
+        # Therefore, the sample code for example outlined here won't work:
+        # https://support.shotgunsoftware.com/entries/26303513-Transcoding
+        
+        params = ""         
+        params += "-threads 2 -vcodec libx264 -me_method umh -directpred 3 -coder ac -me_range 16 -g 250 "
+        params += "-rc_eq 'blurCplx^(1-qComp)' -keyint_min 25 -sc_threshold 40 -i_qfactor 0.71428572 "
+        params += "-b_qfactor 0.76923078 -b_strategy 1 -qcomp 0.6 -qmin 10 -qmax 51 -qdiff 4  -trellis 1 "
+        params += "-subq 6 -partitions +parti8x8+parti4x4+partp8x8+partp4x4+partb8x8 -bidir_refine 1 "
+        params += "-cmp 1 -flags2 fastpskip -flags2 dct8x8 -flags2 mixed_refs -flags2 wpred "
+        params += "-refs 2 -deblockalpha 0 -deblockbeta 0 -bf 3 "
+        
+        # Quality parameter (see https://trac.ffmpeg.org/wiki/Encode/H.264#crf):
+        # "The range of the quantizer scale is 0-51: where 0 is lossless, 23 is default, 
+        # and 51 is worst possible. A lower value is a higher quality and a subjectively 
+        # sane range is 18-28. Consider 18 to be visually lossless or nearly so: it should 
+        # look the same or nearly the same as the input but it isn't technically lossless."
+        #
+        # Note: 15 is the highest quality preset available in the wiretap central export presets.
+        #
+        params += "-crf 15 " 

--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -213,3 +213,6 @@ class ExportSettings(HookBaseClass):
         # Note: 15 is the highest quality preset available in the wiretap central export presets.
         #
         params += "-crf 18 " 
+        
+        return params
+    

--- a/info.yml
+++ b/info.yml
@@ -26,7 +26,7 @@ configuration:
     settings_hook:
         type: hook
         default_value: "{self}/settings.py"
-        description: Contains logic to generate settings and presets for the flame export profile
+        description: Contains logic to generate settings and presets for the Flame export profile
                      used to generate the output. 
     
     shot_parent_entity_type:
@@ -95,8 +95,8 @@ configuration:
                     
     segment_clip_template:
         description: "Toolkit file system template to control where segment based clip files go on disk. 
-                     A segment in flame is a 'block' on the timeline, so a shot may end up with multiple segments. 
-                     This clip file contains flame related metadata that flame uses to deconstruct data as it is
+                     A segment in Flame is a 'block' on the timeline, so a shot may end up with multiple segments. 
+                     This clip file contains Flame related metadata that Flame uses to deconstruct data as it is
                      being read back into the system." 
         type: template
         fields: context, Shot, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], *
@@ -115,7 +115,7 @@ configuration:
         fields: context, Shot, [YYYY], [MM], [DD], [hh], [mm], [ss], *
 
     batch_template:
-        description: Toolkit file system template to control where flame batch files go on disk
+        description: Toolkit file system template to control where Flame batch files go on disk
         type: template
         fields: context, Shot, version, [YYYY], [MM], [DD], [hh], [mm], [ss], *            
         

--- a/info.yml
+++ b/info.yml
@@ -88,7 +88,7 @@ configuration:
                     type: template
                     allows_empty: True
                     default_value: null
-                    fields: context, SEQ, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], *
+                    fields: context, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], *
                 quicktime_publish_type:
                     type: tank_type
                     description: The publish type for quicktimes generated on disk

--- a/info.yml
+++ b/info.yml
@@ -65,18 +65,13 @@ configuration:
             items:
                 name:
                     type: str
-                force_copy:
-                    type: bool
-                    description: By default, exported images are hard linked if possible, meaning that the export
-                                 is quicker and it takes up less space on disk. Setting this option to true will force
-                                 the exporter to always copy the frames when it is doing the export.
-                    default_value: false
+                    description: The name of this preset.
                 publish_type:
                     type: tank_type
-                    description: The publish type for Flame plates
+                    description: The publish type for Flame plates.
                     default_value: "Flame Render"                 
                 template:
-                    description: Toolkit file system template to control where video output goes on disk
+                    description: Toolkit file system template to control where video output goes on disk.
                     type: template
                     fields: context, SEQ, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
                 quicktime_template:
@@ -91,10 +86,10 @@ configuration:
                     fields: context, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], *
                 quicktime_publish_type:
                     type: tank_type
-                    description: The publish type for quicktimes generated on disk
+                    description: The publish type for quicktimes generated on disk.
                     default_value: "Flame Quicktime"
                 upload_quicktime:
-                    description: Upload a quicktime to Shotgun when publishing
+                    description: Upload a quicktime to Shotgun when publishing.
                     type: bool
                     default_value: true
                     

--- a/info.yml
+++ b/info.yml
@@ -65,14 +65,35 @@ configuration:
             items:
                 name:
                     type: str
+                force_copy:
+                    type: bool
+                    description: By default, exported images are hard linked if possible, meaning that the export
+                                 is quicker and it takes up less space on disk. Setting this option to true will force
+                                 the exporter to always copy the frames when it is doing the export.
+                    default_value: false
                 publish_type:
                     type: tank_type
-                    description: The publish type for Flame plates  
-                    default_value: "Flame Plate"                 
+                    description: The publish type for Flame plates
+                    default_value: "Flame Render"                 
                 template:
                     description: Toolkit file system template to control where video output goes on disk
                     type: template
                     fields: context, SEQ, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
+                quicktime_template:
+                    description: If not set to null, a higher res quicktime will be generated and stored on disk, 
+                                 suitable for playback in RV and linked to the version in Shotgun.
+                    type: template
+                    allows_empty: True
+                    default_value: null
+                    fields: context, SEQ, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
+                quicktime_publish_type:
+                    type: tank_type
+                    description: The publish type for quicktimes generated on disk
+                    default_value: "Flame Quicktime"
+                upload_quicktime:
+                    description: Upload a quicktime to Shotgun when publishing
+                    type: bool
+                    default_value: true
                     
     segment_clip_template:
         description: "Toolkit file system template to control where segment based clip files go on disk. 
@@ -82,6 +103,13 @@ configuration:
         type: template
         fields: context, Shot, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], *
 
+    bypass_shotgun_transcoding:
+        description: Try to bypass the Shotgun server side transcoding if possible. This will only generate
+                     generate and upload a h264 quicktime and not a webm, meaning that playback will not be 
+                     supported on all browsers. For more information about this option, please see the documentation.
+        type: bool
+        default_value: false
+        
     shot_clip_template:
         description: Toolkit file system template to control where shot based clip files go on disk
                      

--- a/info.yml
+++ b/info.yml
@@ -81,11 +81,14 @@ configuration:
                     fields: context, SEQ, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
                 quicktime_template:
                     description: If not set to null, a higher res quicktime will be generated and stored on disk, 
-                                 suitable for playback in RV and linked to the version in Shotgun.
+                                 suitable for playback in client based playback tools such as RV. It will be linked
+                                 up with the version in Shotgun. The optional time stamp fields will reflect the 
+                                 time stamp fields of the main render template and you can only include fields that 
+                                 are present in the main render template.
                     type: template
                     allows_empty: True
                     default_value: null
-                    fields: context, SEQ, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
+                    fields: context, SEQ, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], *
                 quicktime_publish_type:
                     type: tank_type
                     description: The publish type for quicktimes generated on disk

--- a/python/tk_flame_export_no_ui/__init__.py
+++ b/python/tk_flame_export_no_ui/__init__.py
@@ -10,5 +10,5 @@
 
 
 from .shotgun_submit import ShotgunSubmitter
-from .export_preset import ExportPreset
+from .export_preset import ExportPresetHandler, ExportPreset
 from .shot_metadata import SegmentMetadata, ShotMetadata

--- a/python/tk_flame_export_no_ui/export_preset.py
+++ b/python/tk_flame_export_no_ui/export_preset.py
@@ -83,15 +83,6 @@ class ExportPreset(object):
         :returns: A name suitable for a render publish
         """
         return self.__get_publish_name(self.get_render_template(), path)        
-
-    def force_copy_render_frames(self):
-        """
-        Returns true if rendered frames should always be copied, false if
-        it's okay to hard link rendered frames.
-        
-        :returns: boolean indicating copy policy
-        """
-        return self._raw_preset["force_copy"]
     
     ############################################################################################################
     # values relating to the quicktime output
@@ -189,7 +180,7 @@ class ExportPreset(object):
                                                          "get_video_preset", 
                                                          preset_name=self.get_name(), 
                                                          name_pattern=escaped_video_name_pattern, 
-                                                         publish_linked=self.force_copy_render_frames())
+                                                         publish_linked=True)
         
         # now merge the video portion into a larger xml chunk which will be 
         # the export preset that we pass to Flame. 

--- a/python/tk_flame_export_no_ui/export_preset.py
+++ b/python/tk_flame_export_no_ui/export_preset.py
@@ -34,7 +34,7 @@ class ExportPreset(object):
     
     def __get_publish_name(self, template, path):
         """
-        Creates a name suitable for a shotgun publish given a path.
+        Creates a name suitable for a Shotgun publish given a path.
         Will return a default name in case name extraction cannot be done.
         
         :param template: Template object to use for field extraction
@@ -148,7 +148,7 @@ class ExportPreset(object):
     
     def upload_quicktime(self):
         """
-        Indicates that quicktimes should be pushed to shotgun.
+        Indicates that quicktimes should be pushed to Shotgun.
         
         :returns: bool flag, true if quicktimes should be uploaded, false if not
         """
@@ -159,7 +159,7 @@ class ExportPreset(object):
     
     def get_xml_path(self):
         """
-        Generate flame export profile settings suitable for generating image sequences
+        Generate Flame export profile settings suitable for generating image sequences
         for all shots. This will return a path on disk where an xml export preset is located.
         
         This preset is combined by loading various sources - some of the main scaffold
@@ -169,7 +169,7 @@ class ExportPreset(object):
         :returns: path to export preset xml file
         """
 
-        # first convert all relevant templates to flame specific form        
+        # first convert all relevant templates to Flame specific form        
         resolved_flame_templates = self.__resolve_flame_templates()
         
         # execute a hook to retrieve all the graphic settings
@@ -186,10 +186,10 @@ class ExportPreset(object):
         # the export preset that we pass to Flame. 
         #
         # a note on xml file formats: 
-        # Each major version of flame typically implements a particular 
+        # Each major version of Flame typically implements a particular 
         # version of the preset xml protocol. This is denoted by a preset version
         # number in the xml file. In order for the integration to run smoothly across
-        # multiple versions of flame, flame ideally needs to be presented with a preset
+        # multiple versions of Flame, Flame ideally needs to be presented with a preset
         # which matches the current preset version. If you present an older version, a
         # warning dialog may pop up which is confusing to users. Therefore, make sure that
         # we always generate xmls with a matching preset version.   
@@ -250,7 +250,7 @@ class ExportPreset(object):
         # wedge in the video settings we got from the hook
         xml = xml.replace("{VIDEO_EXPORT_PRESET}", video_preset_xml)
         
-        # now perform substitutions based on the rest of the resolved flame templates
+        # now perform substitutions based on the rest of the resolved Flame templates
         # make sure we escape any < and > before we add them to the xml
         xml = xml.replace("{SEGMENT_CLIP_NAME_PATTERN}", cgi.escape(resolved_flame_templates["segment_clip_template"]))
         xml = xml.replace("{BATCH_NAME_PATTERN}",        cgi.escape(resolved_flame_templates["batch_template"]))
@@ -264,7 +264,7 @@ class ExportPreset(object):
         
         # The format spec is something like "04"
         # strip off leading zeroes
-        # TODO: flame defaults to zero-padded numbers (e.g. 001, 002, 003 instead of 1, 2, 3)
+        # TODO: Flame defaults to zero-padded numbers (e.g. 001, 002, 003 instead of 1, 2, 3)
         # raise an error in case someone tries to use a template which 
         # does use non-zero padded token.
         format_spec = sequence_key.format_spec.lstrip("0")        
@@ -275,7 +275,7 @@ class ExportPreset(object):
         # also align the padding for versions with the definition in the version template
         version_key = template.keys["version"]
         # the format spec is something like "03"
-        # TODO: flame defaults to zero-padded numbers (e.g. 001, 002, 003 instead of 1, 2, 3)
+        # TODO: Flame defaults to zero-padded numbers (e.g. 001, 002, 003 instead of 1, 2, 3)
         # raise an error in case someone tries to use a template which 
         # does use non-zero padded token.
         format_spec = version_key.format_spec.lstrip("0")
@@ -326,7 +326,7 @@ class ExportPreset(object):
         Convert the toolkit templates defined in the app settings to 
         Flame equivalents.
         
-        :returns: Dictionary of flame template definition strings, keyed by
+        :returns: Dictionary of Flame template definition strings, keyed by
                   the same names as are being used for the templates in the app settings.
         """
         # now we need to take our toolkit templates and inject them into the xml template
@@ -341,8 +341,8 @@ class ExportPreset(object):
         # {Sequence} may be {Scene} or {CustomEntityXX} according to the configuration and the 
         # exact entity type to use is passed into the hook via the the shot_parent_entity_type setting.
         #
-        # The flame export root is set to correspond to the toolkit project, meaning that both the 
-        # flame and toolkit templates share the same root point.
+        # The Flame export root is set to correspond to the toolkit project, meaning that both the 
+        # Flame and toolkit templates share the same root point.
         #
         # The following replacements will be made to convert the toolkit template into Flame equivalents:
         # 

--- a/python/tk_flame_export_no_ui/export_preset.py
+++ b/python/tk_flame_export_no_ui/export_preset.py
@@ -44,7 +44,7 @@ class ExportPreset(object):
         # put together a name for the publish. This should be on a form without a version
         # number, so that it can be used to group together publishes of the same kind.        
         if template is None or not template.validate(path):
-            self._app.log_warning("%s Cannot generate a publish name for '%s'!" % (self, path))
+            self._app.log_warning("%s Cannot generate a publish name for '%s'!" % (template, path))
             publish_name = "Unknown"
         
         else:
@@ -478,18 +478,18 @@ class ExportPresetHandler(object):
         """
         
         self._app.log_debug("Trying to locate an export preset for path '%s'..." % path)
-        matching_template = None
-        for preset_obj in self._export_presets:
+        matching_preset = None
+        for preset_obj in self._export_presets.values():
 
             template = preset_obj.get_render_template()
             if template.validate(path):
-                matching_template = template
                 self._app.log_debug(" - Matching: '%s'" % preset_obj)
+                matching_preset = preset_obj
                 break
             else:
                 self._app.log_debug(" - Not matching: '%s'" % preset_obj)
 
-        return matching_template
+        return matching_preset
         
         
 

--- a/python/tk_flame_export_no_ui/export_preset.py
+++ b/python/tk_flame_export_no_ui/export_preset.py
@@ -287,7 +287,7 @@ class ExportPreset(object):
         # TODO: flame defaults to zero-padded numbers (e.g. 001, 002, 003 instead of 1, 2, 3)
         # raise an error in case someone tries to use a template which 
         # does use non-zero padded token.
-        format_spec = version_key.lstrip("0")
+        format_spec = version_key.format_spec.lstrip("0")
         xml = xml.replace("{VERSION_PADDING}", format_spec)        
         self._app.log_debug("Flame preset generation: Setting version padding to %s based on "
                             "version token in template %s" % (format_spec, template))
@@ -330,7 +330,7 @@ class ExportPreset(object):
         self._app.log_debug("Wrote temporary file '%s'" % file_path)
         return file_path
 
-    def __resolve_flame_templates(self, video_preset):
+    def __resolve_flame_templates(self):
         """
         Convert the toolkit templates defined in the app settings to 
         Flame equivalents.
@@ -434,7 +434,7 @@ class ExportPresetHandler(object):
         self._app = sgtk.platform.current_bundle()
         
         raw_preset_data = self._app.get_setting("plate_presets")
-        self._app.debug("ExportPresetHandler loaded export preset data "
+        self._app.log_debug("ExportPresetHandler loaded export preset data "
                         "from environment: %s" % pprint.pformat(raw_preset_data))
         
         # create export preset objects

--- a/python/tk_flame_export_no_ui/shot_metadata.py
+++ b/python/tk_flame_export_no_ui/shot_metadata.py
@@ -20,14 +20,14 @@ class SegmentMetadata(object):
         """
         Constructor
         """        
-        self.video_info = None          # - info dictionary (as sent from flame) 
+        self.video_info = None          # - info dictionary (as sent from Flame) 
                                         #   for the video portion of this segment
-        self.shotgun_version = None     # - associated shotgun version (dict with type/id)
+        self.shotgun_version = None     # - associated Shotgun version (dict with type/id)
         
     def has_shotgun_version(self):
         """
-        Returns true if a shotgun version exists for the render associated with this segment.
-        If a shotgun version exists, it is implied that a render also exists.
+        Returns true if a Shotgun version exists for the render associated with this segment.
+        If a Shotgun version exists, it is implied that a render also exists.
         
         :returns: boolean flag
         """
@@ -35,19 +35,19 @@ class SegmentMetadata(object):
         
     def get_shotgun_version_id(self):
         """
-        Returns the shotgun id for the version associated with this segment, if there is one.
+        Returns the Shotgun id for the version associated with this segment, if there is one.
         
-        :returns: shotgun version id as int
+        :returns: Shotgun version id as int
         """
         if not self.has_shotgun_version():
-            raise TankError("Cannot get shotgun version id for segment - no version associated!")
+            raise TankError("Cannot get Shotgun version id for segment - no version associated!")
         return self.shotgun_version["id"]
     
     def has_render_export(self):
         """
         Returns true if a render export is associated with this segment, false if not.
         
-        It is possible that an export doesn't have a render file exported if flame for example
+        It is possible that an export doesn't have a render file exported if Flame for example
         prompts the user, asking her/him if they want to override an existing file and they 
         select 'no'
         
@@ -94,16 +94,16 @@ class ShotMetadata(object):
         
         self.name = None                    # shot name
         self.parent_name = None             # parent (sequence) name
-        self.shotgun_parent = None          # shotgun parent entity dictionary
+        self.shotgun_parent = None          # Shotgun parent entity dictionary
         
-        self.created_this_session = False   # was the shotgun shot created in this export session?
+        self.created_this_session = False   # was the Shotgun shot created in this export session?
         self.thumbnail_uploaded = False     # for new shots, has a thumbnail been pushed to Shotgun?
 
-        self.shotgun_id = None              # shotgun shot id
+        self.shotgun_id = None              # Shotgun shot id
         
-        self.shotgun_cut_in = None          # shotgun cut in 
-        self.shotgun_cut_out = None         # shotgun cut out
-        self.shotgun_cut_order = None       # shotgun cut order
+        self.shotgun_cut_in = None          # Shotgun cut in 
+        self.shotgun_cut_out = None         # Shotgun cut out
+        self.shotgun_cut_order = None       # Shotgun cut order
         
         self.new_cut_in = None              # calculated cut in
         self.new_cut_out = None             # calculated cut out
@@ -111,7 +111,7 @@ class ShotMetadata(object):
         
         self.context = None                 # context object for the shot
         
-        self.batch_info = None              # info dictionary (as sent from flame) for the batch export
+        self.batch_info = None              # info dictionary (as sent from Flame) for the batch export
                                             # associated with this shot
         
         self.segment_metadata = {}          # metadata about all the clips associated 
@@ -121,7 +121,7 @@ class ShotMetadata(object):
         """
         Returns true if a batch export is associated with this shot, false if not.
         
-        It is possible that an export doesn't have a batch file exported if flame for example
+        It is possible that an export doesn't have a batch file exported if Flame for example
         prompts the user, asking her/him if they want to override an existing file and they 
         select 'no'
         
@@ -158,24 +158,24 @@ class ShotMetadata(object):
         The frame information coming from Flame includes handles and is out frame exclusive, 
         meaning that the sequence 1,2,3,4,5 is denoted 1-6. 
         
-        :param record_in: Record in parameter for a segment in flame belonging to this shot
-        :param record_out: Record out parameter for a segment in flame belonging to this shot
+        :param record_in: Record in parameter for a segment in Flame belonging to this shot
+        :param record_out: Record out parameter for a segment in Flame belonging to this shot
         """
         
         # the cut in and cut out are reflected by the values stored in the conform
-        # in flame. These are sometimes defaulted to 10:00:00.00 so there may be some
+        # in Flame. These are sometimes defaulted to 10:00:00.00 so there may be some
         # large numbers here.
         cut_in = record_in 
         cut_out = record_out 
         
-        # now, note that flame is cut-out-exclusive, meaning that the out frame
+        # now, note that Flame is cut-out-exclusive, meaning that the out frame
         # is actually not the last frame played back but the frame after that.
-        # in the shotgun universe, we want last frame *inclusive* instead
+        # in the Shotgun universe, we want last frame *inclusive* instead
         cut_out = cut_out - 1
         
         # now it is time to update the *SHOT* lengths. With Flame's collating,
         # a single shot may be made up of several *segments*. The cut information
-        # we are getting from flame is per segment. We need to "grow" the shot range
+        # we are getting from Flame is per segment. We need to "grow" the shot range
         # so that it will encompass all segments.
         if self.new_cut_in is None:
             # no value yet

--- a/python/tk_flame_export_no_ui/shot_metadata.py
+++ b/python/tk_flame_export_no_ui/shot_metadata.py
@@ -20,13 +20,14 @@ class SegmentMetadata(object):
         """
         Constructor
         """        
-        self.video_info = None          # info dictionary (as sent from flame) for the video portion of this segment
-        self.shotgun_version = None     # associated shotgun version (dict with type/id)
+        self.video_info = None          # - info dictionary (as sent from flame) 
+                                        #   for the video portion of this segment
+        self.shotgun_version = None     # - associated shotgun version (dict with type/id)
         
     def has_shotgun_version(self):
         """
         Returns true if a shotgun version exists for the render associated with this segment.
-        If a shotgun version exists, it is implied that a render also exists
+        If a shotgun version exists, it is implied that a render also exists.
         
         :returns: boolean flag
         """
@@ -83,7 +84,6 @@ class SegmentMetadata(object):
 class ShotMetadata(object):
     """
     Simple value wrapper class which holds various properties associated with a shot.
-    This object is passed down the export pipeline.
     """
 
     def __init__(self):

--- a/python/tk_flame_export_no_ui/shotgun_submit.py
+++ b/python/tk_flame_export_no_ui/shotgun_submit.py
@@ -459,6 +459,30 @@ class ShotgunSubmitter(object):
                     
         return batch_item
 
+    def upload_version_thumbnails(self, items):
+        """
+        Upload version thumbnails to Shotgun.
+        
+        Given a list of already existing versions, extract thumbnails from flame
+        and upload these to Shotgun. The items input is a list of dictionaries with
+        each dictionary having keys version_id and path, where path is a path to 
+        an exported flame render from which a thumbnail is being extracted.
+        
+        :param items: list of dicts. For details, see above.
+        """
+        for i in items:
+            version_id = i["version_id"]
+            path = i["path"] 
+            
+            self._app.log_debug("Attempting to extract and upload thumbnail for version %s..." % version_id)
+            jpeg_path = self.__extract_thumbnail(path)
+            if jpeg_path:
+                # we have a valid thumbnail - push it to shotgn
+                self._app.log_debug("Push version thumbnail to shotgun...")
+                self._app.shotgun.upload_thumbnail("Version", version_id, jpeg_path)
+                self._app.log_debug("...upload complete!")
+                # try to clean up
+                self.__clean_up_temp_file(jpeg_path)
 
     def upload_quicktime(self, version_id, path, width, height):        
         """

--- a/python/tk_flame_export_no_ui/shotgun_submit.py
+++ b/python/tk_flame_export_no_ui/shotgun_submit.py
@@ -698,7 +698,13 @@ class ShotgunSubmitter(object):
         # note: the -r framerate argument seems to confuse ffmpeg so I am omitting that
         # instead, quicktimes are generated at a default of 25fps.
         
-        ffmpeg_cmd = "%s -f rawvideo -top -1 -pix_fmt rgb24 -s %sx%s -i - -y" % (self._app.engine.get_ffmpeg_path(),
+        ffmpeg_executable = self._app.execute_hook_method("settings_hook", "get_external_ffmpeg_location")
+        
+        if ffmpeg_executable is None:
+            # use Flame default
+            ffmpeg_executable = self._app.engine.get_ffmpeg_path()
+        
+        ffmpeg_cmd = "%s -f rawvideo -top -1 -pix_fmt rgb24 -s %sx%s -i - -y" % (ffmpeg_executable,
                                                                                  target_width,
                                                                                  target_height)
                                                                                        

--- a/python/tk_flame_export_no_ui/shotgun_submit.py
+++ b/python/tk_flame_export_no_ui/shotgun_submit.py
@@ -25,7 +25,7 @@ class ShotgunSubmitter(object):
     
     # constants
     
-    # default height for shotgun uploads
+    # default height for Shotgun uploads
     # see https://support.shotgunsoftware.com/entries/26303513-Transcoding
     SHOTGUN_QUICKTIME_TARGET_HEIGHT = 720 
     
@@ -50,7 +50,7 @@ class ShotgunSubmitter(object):
         Create a scaffold in Shotgun and on disk to represent Shots.
         This method will
         
-        - Create sequences and shots in shotgun if they don't already exist
+        - Create sequences and shots in Shotgun if they don't already exist
         - Create folders on disk for new shots
         - Compute tk contexts for all shots
         
@@ -70,7 +70,7 @@ class ShotgunSubmitter(object):
         self._app.engine.show_busy("Preparing Shotgun...", "Preparing Shots for export...")
         
         try:
-            # find and create objects in shotgun
+            # find and create objects in Shotgun
             shot_metadata_list = self._resolve_sg_shot_structure(parent_name, shot_names)
             
             # set up metadata objects grouped by sequence in our data structure
@@ -133,7 +133,7 @@ class ShotgunSubmitter(object):
                                                [["code", "is", parent_name], ["project", "is", project]]) 
         
         if sg_parent:
-            self._app.log_debug("Parent %s already exists in shotgun." % sg_parent)
+            self._app.log_debug("Parent %s already exists in Shotgun." % sg_parent)
             
         else:
             # Create a new parent object in Shotgun
@@ -173,7 +173,7 @@ class ShotgunSubmitter(object):
         # now attempt to retrieve metadata for all shots. The shots that are not found are then created.
         self._app.engine.show_busy("Preparing Shotgun...", "Loading Shot data...")
         
-        self._app.log_debug("Loading shots from shotgun...")
+        self._app.log_debug("Loading shots from Shotgun...")
         sg_shots = self._app.shotgun.find("Shot", 
                                           [["code", "in", shot_names], 
                                            [self._shot_parent_link_field, "is", sg_parent]],
@@ -205,7 +205,7 @@ class ShotgunSubmitter(object):
                                   self._shot_parent_link_field: sg_parent,
                                   "task_template": sg_task_template,
                                   "project": project} }
-                self._app.log_debug("Adding to shotgun batch queue: %s" % batch)
+                self._app.log_debug("Adding to Shotgun batch queue: %s" % batch)
                 sg_batch_data.append(batch)
         
         if len(sg_batch_data) > 0:
@@ -242,7 +242,7 @@ class ShotgunSubmitter(object):
 
     def register_batch_publish(self, context, path, comments, version_number):
         """
-        Creates a publish record in shotgun for a flame batch file.
+        Creates a publish record in Shotgun for a Flame batch file.
         
         :param context: Context to associate the publish with
         :param path: Path to the batch file on disk
@@ -274,7 +274,7 @@ class ShotgunSubmitter(object):
             "published_file_type": publish_type,
         }
         
-        self._app.log_debug("Register publish in shotgun: %s" % str(args))        
+        self._app.log_debug("Register publish in Shotgun: %s" % str(args))        
         sg_publish_data = sgtk.util.register_publish(**args)
         self._app.log_debug("Register complete: %s" % sg_publish_data)
         return sg_publish_data
@@ -282,7 +282,7 @@ class ShotgunSubmitter(object):
         
     def register_video_publish(self, export_preset, context, width, height, path, quicktime_path, comments, version_number, make_shot_thumb):        
         """
-        Creates a publish record in shotgun for a flame video file.
+        Creates a publish record in Shotgun for a Flame video file.
         Optionally also creates a second publish record for an equivalent local quicktime
         
         :param export_preset: The export preset associated with this publish
@@ -323,7 +323,7 @@ class ShotgunSubmitter(object):
         if make_shot_thumb and jpeg_path:
             args["update_entity_thumbnail"] = True
         
-        self._app.log_debug("Register render publish in shotgun: %s" % str(args))        
+        self._app.log_debug("Register render publish in Shotgun: %s" % str(args))        
         sg_publish_data = sgtk.util.register_publish(**args)
         self._app.log_debug("Register complete: %s" % sg_publish_data)
 
@@ -343,7 +343,7 @@ class ShotgunSubmitter(object):
                         "name": preset_obj.get_quicktime_publish_name(quicktime_path),
                         "published_file_type": preset_obj.get_quicktime_publish_type() }
         
-            self._app.log_debug("Register quicktime publish in shotgun: %s" % str(mov_args))        
+            self._app.log_debug("Register quicktime publish in Shotgun: %s" % str(mov_args))        
             sg_mov_data = sgtk.util.register_publish(**mov_args)
             self._app.log_debug("Register complete: %s" % sg_mov_data)
 
@@ -378,21 +378,21 @@ class ShotgunSubmitter(object):
     
     def create_version(self, context, path, user_comments, sg_publish_data, aspect_ratio):        
         """
-        Creates a single version record in shotgun.
+        Creates a single version record in Shotgun.
         
         Note: If you are creating more than one version at the same time, use 
               create_version_batch for performance.
                 
         :param context: The context for the shot that the submission is associated with, 
                         in serialized form.
-        :param path: Path to frames, flame style path with [1234-1234] sequence marker.
+        :param path: Path to frames, Flame style path with [1234-1234] sequence marker.
         :param user_comments: Comments entered by the user at export start.
-        :param sg_publish_data: Std shotgun dictionary (with type and id), representing the publish
+        :param sg_publish_data: Std Shotgun dictionary (with type and id), representing the publish
                                 in Shotgun that has been carried out for this asset.
         :param aspect_ratio: Aspect ratio of the images
-        :returns: The created shotgun record
+        :returns: The created Shotgun record
         """
-        self._app.log_debug("Preparing data for version creation in shotgun...")
+        self._app.log_debug("Preparing data for version creation in Shotgun...")
         sg_batch_payload = []
         version_batch = self.create_version_batch(context, path, user_comments, sg_publish_data, aspect_ratio)
         sg_batch_payload.append(version_batch)
@@ -408,12 +408,12 @@ class ShotgunSubmitter(object):
 
         :param context: The context for the shot that the submission is associated with, 
                         in serialized form.
-        :param path: Path to frames, flame style path with [1234-1234] sequence marker.
+        :param path: Path to frames, Flame style path with [1234-1234] sequence marker.
         :param user_comments: Comments entered by the user at export start.
-        :param sg_publish_data: Std shotgun dictionary (with type and id), representing the publish
+        :param sg_publish_data: Std Shotgun dictionary (with type and id), representing the publish
                                 in Shotgun that has been carried out for this asset.
         :param aspect_ratio: Aspect ratio of the images        
-        :returns: dictionary suitable to be used as part of a shotgun batch call
+        :returns: dictionary suitable to be used as part of a Shotgun batch call
         """
         
         batch_item = {"request_type": "create",
@@ -435,13 +435,13 @@ class ShotgunSubmitter(object):
         batch_item["data"]["user"] = context.user
         batch_item["data"]["sg_task"] = context.task
         
-        # now figure out the frame numbers. For an initial shotgun export this is easy because we have
+        # now figure out the frame numbers. For an initial Shotgun export this is easy because we have
         # access to the export profile which defines the frame offset which maps actual frames on disk with
-        # frames in the cut space inside of flame. However, for batch rendering, which is currently stateless,
+        # frames in the cut space inside of Flame. However, for batch rendering, which is currently stateless,
         # this info is not available. It may be possible to extract it from the clip xml files, but for now,
         # lets keep it simple and look at the sequence file path to extract this data.
         #
-        # flame sequence tokens are on the form "[1001-1100]"
+        # Flame sequence tokens are on the form "[1001-1100]"
         re_match = re.search("\[([0-9]+)-([0-9]+)\]\.", path)
         if not re_match:
             self._app.log_warning("No frame range information found in path '%s'. "
@@ -449,14 +449,6 @@ class ShotgunSubmitter(object):
         else:
             try:
                 (first_str, last_str) = re_match.groups()
-                # remove leading zeroes and convert
-                first_str = first_str.lstrip("0")
-                last_str = last_str.lstrip("0")
-                # handle the case when a frame number is zero
-                if first_str == "":
-                    first_str = "0"
-                if last_str == "":
-                    last_str = "0"
                 first_frame = int(first_str)
                 last_frame = int(last_str)
             
@@ -495,10 +487,10 @@ class ShotgunSubmitter(object):
         """
         Upload version thumbnails to Shotgun.
         
-        Given a list of already existing versions, extract thumbnails from flame
+        Given a list of already existing versions, extract thumbnails from Flame
         and upload these to Shotgun. The items input is a list of dictionaries with
         each dictionary having keys version_id width, height and path, where path is a path to 
-        an exported flame render from which a thumbnail is being extracted.
+        an exported Flame render from which a thumbnail is being extracted.
         
         :param items: list of dicts. For details, see above.
         """
@@ -512,7 +504,7 @@ class ShotgunSubmitter(object):
             jpeg_path = self.__extract_thumbnail(path, width, height)
             if jpeg_path:
                 # we have a valid thumbnail - push it to shotgn
-                self._app.log_debug("Push version thumbnail to shotgun...")
+                self._app.log_debug("Push version thumbnail to Shotgun...")
                 self._app.shotgun.upload_thumbnail("Version", version_id, jpeg_path)
                 self._app.log_debug("...upload complete!")
                 # try to clean up
@@ -520,16 +512,16 @@ class ShotgunSubmitter(object):
 
     def upload_quicktime(self, version_id, path, width, height):        
         """
-        Generates a quicktime based on flame image data. Then uploads it to
+        Generates a quicktime based on Flame image data. Then uploads it to
         Shotgun.
 
         This method will generate a quicktime using ffmpeg. It tries to find
-        the closest resolution to 720p (which is shotgun's recommended resolution)
+        the closest resolution to 720p (which is Shotgun's recommended resolution)
         in order to make the quicktime size as small as possible. Once generated,
         the quicktime is uploaded to Shotgun and the local temp file is deleted.
         
-        :param version_id: The id for the shotgun version to which we are uploading a quicktime.
-        :param path: Path to frames, flame style path with [1234-1234] sequence marker.
+        :param version_id: The id for the Shotgun version to which we are uploading a quicktime.
+        :param path: Path to frames, Flame style path with [1234-1234] sequence marker.
         :param width: Image width in pixels
         :param height: Image height in pixels
         """
@@ -546,11 +538,11 @@ class ShotgunSubmitter(object):
         # get transcode params from hook
         ffmpeg_presets = self._app.execute_hook_method("settings_hook", "get_ffmpeg_quicktime_encode_parameters")        
         
-        # get a temp path - keep the filename nice because this will be uploaded to shotgun
+        # get a temp path - keep the filename nice because this will be uploaded to Shotgun
         tmp_folder = os.path.join(self._app.engine.get_backburner_tmp(), "shotgun_flame_tmp_%s" % uuid.uuid4().hex)
         os.mkdir(tmp_folder)
         
-        # format a nice name for the temp quicktime because this name will be visible in shotgun
+        # format a nice name for the temp quicktime because this name will be visible in Shotgun
         # /path/to/filename -> filename
         # /path/to/filename.ext -> filename
         # /path/to/filename.%04d.ext -> filename
@@ -562,15 +554,15 @@ class ShotgunSubmitter(object):
         self.__do_quicktime_transcode(path, tmp_quicktime, scaled_down_width, scaled_down_height, ffmpeg_presets)                
         
         # upload quicktime to Shotgun
-        self._app.log_debug("Begin upload of quicktime to shotgun...")
+        self._app.log_debug("Begin upload of quicktime to Shotgun...")
         
         try:
         
-            # check if we should attempt bypassing shotgun transcoding
+            # check if we should attempt bypassing Shotgun transcoding
             bypass_server_transcoding = False
             if self._app.get_setting("bypass_shotgun_transcoding"):
                 
-                self._app.log_debug("Bypass shotgun transcoding setting enabled.")
+                self._app.log_debug("Bypass Shotgun transcoding setting enabled.")
                 if scaled_down_height != self.SHOTGUN_QUICKTIME_TARGET_HEIGHT:
                     self._app.log_debug("However, generated quicktime has height %s which is non-compliant, so "
                                         "will have to fall back on to server side transcoding." % scaled_down_height)
@@ -596,10 +588,10 @@ class ShotgunSubmitter(object):
     
     def create_local_quicktime(self, version_id, path, quicktime_path, width, height):
         """
-        Generates a quicktime based on flame image data.
+        Generates a quicktime based on Flame image data.
 
-        :param version_id: The id for the shotgun version to which we are uploading a quicktime.
-        :param path: Path to frames, flame style path with [1234-1234] sequence marker.
+        :param version_id: The id for the Shotgun version to which we are uploading a quicktime.
+        :param path: Path to frames, Flame style path with [1234-1234] sequence marker.
         :param quicktime_path: Path to the quicktime we want to generate
         :param width: Image width in pixels
         :param height: Image height in pixels
@@ -625,12 +617,12 @@ class ShotgunSubmitter(object):
         # now update the corresponding version's path to movie field
         self._app.log_debug("Setting sg_path_to_movie to '%s' for Version %s" % (quicktime_path, version_id))
         self._app.shotgun.update("Version", version_id, {"sg_path_to_movie": quicktime_path})
-        self._app.log_debug("...shotgun update complete!")
+        self._app.log_debug("...Shotgun update complete!")
     
     
     def __do_quicktime_transcode(self, input_path, output_path, target_width, target_height, ffmpeg_presets):
         """
-        Create a quicktime based on flame media.
+        Create a quicktime based on Flame media.
         
         :param input_path: Path to input image sequence
         :param output_path: Path to quicktime to be generated
@@ -643,8 +635,8 @@ class ShotgunSubmitter(object):
 
         # first assemble the readframe syntax. This will use the wiretap API to emit a stream of 
         # image data to stdout that we can pipe into ffmpeg. We use this because the ffmpeg version
-        # coming with flame is from 2009 and doesn't support dpx files but also to make sure that
-        # all file formats that flame supports (e.g. exrs) can be converted.
+        # coming with Flame is from 2009 and doesn't support dpx files but also to make sure that
+        # all file formats that Flame supports (e.g. exrs) can be converted.
         # 
         # Syntax:
         #
@@ -765,10 +757,10 @@ class ShotgunSubmitter(object):
 
     def __get_tk_path_from_flame_plate_path(self, flame_path):
         """
-        Given a xxx.[1234-1234].exr style flame plate path,
+        Given a xxx.[1234-1234].exr style Flame plate path,
         return the equivalent, normalized tk path, e.g. xxx.%04d.exr
         
-        :param flame_path: flame style plate path (must match the plate template)
+        :param flame_path: Flame style plate path (must match the plate template)
         :returns: tk equivalent
         """
         template = self._app.sgtk.template_from_path(flame_path)
@@ -778,12 +770,12 @@ class ShotgunSubmitter(object):
 
     def __extract_thumbnail(self, path, width, height):
         """
-        Extracts a jpeg image in a temp location from a given sequence in flame.
+        Extracts a jpeg image in a temp location from a given sequence in Flame.
         The wiretap system will be used to access the media.
         
         It's the caller's responsibility to delete this generated file after use.
         
-        :param path: flame path to extract to
+        :param path: Flame path to extract to
         :param width: the width of the images in path
         :param height: the height of the images in path
         :returns: None if extraction didn't work, otherwise a path to a jpeg file

--- a/python/tk_flame_export_no_ui/shotgun_submit.py
+++ b/python/tk_flame_export_no_ui/shotgun_submit.py
@@ -335,7 +335,7 @@ class ShotgunSubmitter(object):
                         
                         "dependency_ids": [ sg_publish_data["id"] ], # set a dependency to the main render
                         "path": quicktime_path,
-                        "name": preset_obj.get_quicktime_publish_name(path),
+                        "name": preset_obj.get_quicktime_publish_name(quicktime_path),
                         "published_file_type": preset_obj.get_quicktime_publish_type() }
         
             self._app.log_debug("Register quicktime publish in shotgun: %s" % str(mov_args))        


### PR DESCRIPTION
A number of changes and improvements to quicktime generation.
A number of improvements to code structure and organization.

- Adds a per-preset config option `plate_presets.force_copy` which controls the hard link/copy export preference in flame
- Adds an optional per-preset config option `plate_presets.quicktime_template` which when populated will generate a local quicktime on disk and associate that with the version in Shotgun, enabling screening room for RV functionality. The output settings for this quicktime is controlled separate from the output settings for the shotgun upload quicktime. All handled in the hook.
- Adds a per-preset config option `plate_presets.upload_quicktime` which can be set to False for maximum speed - in this case no shotgun quicktime will be generated nor uploaded.
- Adds a app wide config option bypass_shotgun_transcoding which means that the app will attempt to bypass shotgun server side transcoding and upload its generated quicktime directly to the special `Version.sg_uploaded_movie_mp4` field in shotgun. This means that no transcoding will happen on the Shotgun site - once the quicktime has been uploaded, it is instantly playable. However, because it is not currently doing the webm version of the quicktime, playback is limited to iOS, Chrome and Safari (not Firefox).
