### PR TITLE
#30135 Batch render upgrades to support 2016.1

### DIFF
--- a/app.py
+++ b/app.py
@@ -636,7 +636,7 @@ class FlameExport(Application):
                         # check if we should also generate a quicktime. In that case, we make a publish for
                         # that too at the same time.
                         quicktime_path = None
-                        if self._export_preset.make_highres_quicktime():
+                        if self._export_preset.highres_quicktime_enabled():
                             render_path = segment_metadata.get_render_path()
                             quicktime_path = self._export_preset.quicktime_path_from_render_path(render_path)
                         
@@ -754,7 +754,7 @@ class FlameExport(Application):
         # note that this happens in a separate loop after the upload loop to ensure that 
         # these tasks happen last.
 
-        if self._export_preset.make_highres_quicktime():
+        if self._export_preset.highres_quicktime_enabled():
             # let's create quicktimes suitable for local playback (for example in RV)
             # create one separate backburner job for each upload for parallelisation 
             # this are pushed onto the queue after any Shotgun transcoding jobs. 
@@ -1149,7 +1149,7 @@ class FlameExport(Application):
         full_flame_batch_render_path = os.path.join(info.get("exportPath"), info.get("resolvedPath"))
         
         quicktime_path = None
-        if export_preset_obj.make_batch_highres_quicktime() and send_to_review:
+        if export_preset_obj.batch_highres_quicktime_enabled() and send_to_review:
             # note 1: Only if the send to review button is clicked, a quicktime will be generated. 
             # note 2: at this point we have already validated the path and know it conforms with the toolkit templates.
             quicktime_path = export_preset_obj.batch_quicktime_path_from_render_path(full_flame_batch_render_path)
@@ -1194,7 +1194,7 @@ class FlameExport(Application):
                                                         info["fps"])
             
             # Step 4 - Generate high res local quicktime
-            if export_preset_obj.make_batch_highres_quicktime():
+            if export_preset_obj.batch_highres_quicktime_enabled():
                 self._sg_submit_helper.create_local_quicktime(export_preset_obj.get_name(),
                                                               sg_version_data["id"], 
                                                               full_flame_batch_render_path, 

--- a/app.py
+++ b/app.py
@@ -878,7 +878,7 @@ class FlameExport(Application):
 
         # first check if the resolved paths match our templates in the settings. Otherwise ignore the export
         self.log_debug("Checking if the render path '%s' is recognized by toolkit..." % render_path)
-        self._batch_export_preset = self.export_preset_handler.get_preset_for_render_path(render_path)
+        self._batch_export_preset = self.export_preset_handler.get_preset_for_batch_render_path(render_path)
         if self._batch_export_preset is None:
             self.log_debug("This path does not appear to match any toolkit render paths. Ignoring.")
             return None
@@ -1146,19 +1146,19 @@ class FlameExport(Application):
         self._sg_submit_helper.register_batch_publish(context, batch_path, description, version_number)
 
         # Now register the rendered images as a published plate in Shotgun
-        full_flame_plate_path = os.path.join(info.get("exportPath"), info.get("resolvedPath"))
+        full_flame_batch_render_path = os.path.join(info.get("exportPath"), info.get("resolvedPath"))
         
         quicktime_path = None
-        if export_preset_obj.make_highres_quicktime() and send_to_review:
+        if export_preset_obj.make_batch_highres_quicktime() and send_to_review:
             # note 1: Only if the send to review button is clicked, a quicktime will be generated. 
             # note 2: at this point we have already validated the path and know it conforms with the toolkit templates.
-            quicktime_path = export_preset_obj.quicktime_path_from_render_path(full_flame_plate_path)
+            quicktime_path = export_preset_obj.batch_quicktime_path_from_render_path(full_flame_batch_render_path)
         
         sg_data = self._sg_submit_helper.register_video_publish(export_preset_obj.get_name(),
                                                                 context, 
                                                                 info["width"], 
                                                                 info["height"],                                                                
-                                                                full_flame_plate_path, 
+                                                                full_flame_batch_render_path, 
                                                                 quicktime_path,
                                                                 description,
                                                                 version_number, 
@@ -1170,7 +1170,7 @@ class FlameExport(Application):
                         
             # Step 1 - Create Shotgun Version
             sg_version_data = self._sg_submit_helper.create_version(context, 
-                                                                    full_flame_plate_path,
+                                                                    full_flame_batch_render_path,
                                                                     description,
                                                                     sg_data, 
                                                                     info["aspectRatio"])     
@@ -1181,23 +1181,23 @@ class FlameExport(Application):
                 version_info = {"version_id": sg_version_data["id"], 
                                 "width": info["width"],
                                 "height": info["height"],
-                                "path": full_flame_plate_path}
+                                "path": full_flame_batch_render_path}
                 self._sg_submit_helper.upload_version_thumbnails([version_info])                
                 
             # Step 3 - Generate and upload quicktime
             if export_preset_obj.upload_quicktime():
                 # and upload a quicktime to Shotgun
                 self._sg_submit_helper.upload_quicktime(sg_version_data["id"], 
-                                                        full_flame_plate_path, 
+                                                        full_flame_batch_render_path, 
                                                         info["width"], 
                                                         info["height"],
                                                         info["fps"])
             
             # Step 4 - Generate high res local quicktime
-            if export_preset_obj.make_highres_quicktime():
+            if export_preset_obj.make_batch_highres_quicktime():
                 self._sg_submit_helper.create_local_quicktime(export_preset_obj.get_name(),
                                                               sg_version_data["id"], 
-                                                              full_flame_plate_path, 
+                                                              full_flame_batch_render_path, 
                                                               quicktime_path, 
                                                               info["width"], 
                                                               info["height"],

--- a/info.yml
+++ b/info.yml
@@ -63,17 +63,21 @@ configuration:
         values:
             type: dict
             items:
+            
                 name:
                     type: str
                     description: The name of this preset.
+                
                 publish_type:
                     type: tank_type
                     description: The publish type for Flame plates.
                     default_value: "Flame Render"                 
+                
                 template:
-                    description: Toolkit file system template to control where video output goes on disk.
+                    description: Toolkit file system template to control where plate output goes on disk.
                     type: template
                     fields: context, SEQ, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
+                
                 quicktime_template:
                     description: If not set to null, a higher res quicktime will be generated and stored on disk, 
                                  suitable for playback in client based playback tools such as RV. It will be linked
@@ -84,10 +88,34 @@ configuration:
                     allows_empty: True
                     default_value: null
                     fields: context, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], *
+                
+                
+                batch_render_template:
+                    description: The output on disk when doing batch renders in flame. This setting is only
+                                 supported in Flame 2016 Ext 1 and above. If set to null, batch renders will be 
+                                 written to the same location where the initial export is written.
+                    type: template
+                    allows_empty: True
+                    default_value: null
+                    fields: context, SEQ, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
+
+
+                batch_quicktime_template:
+                    description: High res quicktime output for batch renders. If not set to null, a higher res 
+                                 quicktime will be generated and stored on disk, suitable for playback in client 
+                                 based playback tools such as RV. It will be linked up with the version in Shotgun. 
+                                 The optional time stamp fields will reflect the time stamp fields of the main render 
+                                 template and you can only include fields that are present in the main batch render template.
+                    type: template
+                    allows_empty: True
+                    default_value: null
+                    fields: context, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], *
+                
                 quicktime_publish_type:
                     type: tank_type
                     description: The publish type for quicktimes generated on disk.
                     default_value: "Flame Quicktime"
+                
                 upload_quicktime:
                     description: Upload a quicktime to Shotgun when publishing.
                     type: bool

--- a/python/tk_flame_export_no_ui/export_preset.py
+++ b/python/tk_flame_export_no_ui/export_preset.py
@@ -103,13 +103,13 @@ class ExportPreset(object):
     ############################################################################################################
     # values relating to the quicktime output
 
-    def make_highres_quicktime(self):
+    def highres_quicktime_enabled(self):
         """
         :returns: True if a high res quicktime should be generated, False if not.
         """
         return self.get_quicktime_template() is not None
     
-    def make_batch_highres_quicktime(self):
+    def batch_highres_quicktime_enabled(self):
         """
         :returns: True if a high res batch quicktime should be generated, False if not.
         """


### PR DESCRIPTION
In Flame 2016 extension 1, the batch render export profile interface changed. This change upgrades the flame integration so that it supports these changes in 2016.1.

The shot export xml now requires a new `outputPathPattern` key which defines where batch renders should go on disk.

This means that you can *independently* configure the location of the initial rendered plates and the location of subsequent batch renders (e.g. comp renders). 