### PR TITLE
SMOK-45630 | Get publish name for batch render

### DIFF
--- a/app.py
+++ b/app.py
@@ -960,7 +960,7 @@ class FlameExport(Application):
                     request["comments"],
                     request["version"],
                     request["create_shot_thumbnail"],
-                    batch_render=False
+                    is_batch_render=False
                 )
 
                 if request["version_id"]:
@@ -1095,7 +1095,7 @@ class FlameExport(Application):
             description,
             version_number,
             make_shot_thumb=False,
-            batch_render=True
+            is_batch_render=True
         )
         
         # Finally, create a version record in Shotgun, generate a quicktime and upload it

--- a/app.py
+++ b/app.py
@@ -959,7 +959,8 @@ class FlameExport(Application):
                     request["quicktime_path"],
                     request["comments"],
                     request["version"],
-                    request["create_shot_thumbnail"]
+                    request["create_shot_thumbnail"],
+                    batch_render=False
                 )
 
                 if request["version_id"]:
@@ -1093,7 +1094,8 @@ class FlameExport(Application):
             quicktime_path,
             description,
             version_number,
-            make_shot_thumb=False
+            make_shot_thumb=False,
+            batch_render=True
         )
         
         # Finally, create a version record in Shotgun, generate a quicktime and upload it

--- a/python/export_utils/export_preset.py
+++ b/python/export_utils/export_preset.py
@@ -116,10 +116,10 @@ class ExportPreset(object):
         :param path: Path to generate name for
         :returns: A name suitable for a render publish
         """
-        publish_name = self.__get_publish_name(self.get_batch_render_template(), path)
+        publish_name = self.__get_publish_name(self.get_render_template(), path)
 
-        if publish_name == "Unknown":
-            publish_name = self.__get_publish_name(self.get_render_template(), path)
+        if publish_name == "Unknown": 
+            publish_name = self.__get_publish_name(self.get_batch_render_template(), path)
 
         return publish_name
 

--- a/python/export_utils/export_preset.py
+++ b/python/export_utils/export_preset.py
@@ -108,20 +108,25 @@ class ExportPreset(object):
         :returns: The publish type to use for renders
         """
         return self._raw_preset["publish_type"]
-    
+
     def get_render_publish_name(self, path):
         """
-        Generate a name suitable for a publish.
-        
+        Generate a name suitable for a publish based on the render template
+
         :param path: Path to generate name for
         :returns: A name suitable for a render publish
         """
-        publish_name = self.__get_publish_name(self.get_render_template(), path)
+        return self.__get_publish_name(self.get_render_template(), path)
 
-        if publish_name == "Unknown": 
-            publish_name = self.__get_publish_name(self.get_batch_render_template(), path)
+    def get_batch_render_publish_name(self, path):
+        """
+        Generate a name suitable for a publish based on the batch render template
 
-        return publish_name
+        :param path: Path to generate name for
+        :returns: A name suitable for a render publish
+        """
+        return self.__get_publish_name(self.get_batch_render_template(), path)
+
 
     def get_handles_length(self):
         """

--- a/python/export_utils/export_preset.py
+++ b/python/export_utils/export_preset.py
@@ -116,7 +116,12 @@ class ExportPreset(object):
         :param path: Path to generate name for
         :returns: A name suitable for a render publish
         """
-        return self.__get_publish_name(self.get_render_template(), path)        
+        publish_name = self.__get_publish_name(self.get_batch_render_template(), path)
+
+        if publish_name == "Unknown":
+            publish_name = self.__get_publish_name(self.get_render_template(), path)
+
+        return publish_name
 
     def get_handles_length(self):
         """

--- a/python/export_utils/shotgun_submit.py
+++ b/python/export_utils/shotgun_submit.py
@@ -81,7 +81,7 @@ class ShotgunSubmitter(object):
         self._app.log_debug("Register complete: %s" % sg_publish_data)
         return sg_publish_data
         
-    def register_video_publish(self, export_preset, context, width, height, path, quicktime_path, comments, version_number, make_shot_thumb):
+    def register_video_publish(self, export_preset, context, width, height, path, quicktime_path, comments, version_number, make_shot_thumb, batch_render):
         """
         Creates a publish record in Shotgun for a Flame video file.
         Optionally also creates a second publish record for an equivalent local quicktime
@@ -97,6 +97,7 @@ class ShotgunSubmitter(object):
         :param version_number: The version number to use
         :param make_shot_thumb: If set to True, the thumbnail that gets associated with the
                                 publish will also be pushed to the associated entity.
+        :param batch_render: If set to True, the publish is generated from a Batch render
         :returns: Shotgun data for the created item
         """
         self._app.log_debug("Creating video publish in Shotgun for %s..." % path)
@@ -106,7 +107,13 @@ class ShotgunSubmitter(object):
 
         # extract thumbnail
         jpeg_path = self.__extract_thumbnail(path, width, height)
-        
+
+        # The video publish is the result of a Batch render
+        if batch_render:
+            publish_name = preset_obj.get_batch_render_publish_name(path)
+        else:
+            publish_name = preset_obj.get_render_publish_name(path)
+
         # now do the main sequence publish
         args = {
             "tk": self._app.sgtk,
@@ -117,7 +124,7 @@ class ShotgunSubmitter(object):
             "task": context.task,
             "thumbnail_path": jpeg_path,
             "path": path,
-            "name": preset_obj.get_render_publish_name(path),
+            "name": publish_name,
             "published_file_type": preset_obj.get_render_publish_type()
         }
                 

--- a/python/export_utils/shotgun_submit.py
+++ b/python/export_utils/shotgun_submit.py
@@ -81,7 +81,7 @@ class ShotgunSubmitter(object):
         self._app.log_debug("Register complete: %s" % sg_publish_data)
         return sg_publish_data
         
-    def register_video_publish(self, export_preset, context, width, height, path, quicktime_path, comments, version_number, make_shot_thumb, batch_render):
+    def register_video_publish(self, export_preset, context, width, height, path, quicktime_path, comments, version_number, make_shot_thumb, is_batch_render):
         """
         Creates a publish record in Shotgun for a Flame video file.
         Optionally also creates a second publish record for an equivalent local quicktime
@@ -97,7 +97,7 @@ class ShotgunSubmitter(object):
         :param version_number: The version number to use
         :param make_shot_thumb: If set to True, the thumbnail that gets associated with the
                                 publish will also be pushed to the associated entity.
-        :param batch_render: If set to True, the publish is generated from a Batch render
+        :param is_batch_render: If set to True, the publish is generated from a Batch render
         :returns: Shotgun data for the created item
         """
         self._app.log_debug("Creating video publish in Shotgun for %s..." % path)
@@ -109,7 +109,7 @@ class ShotgunSubmitter(object):
         jpeg_path = self.__extract_thumbnail(path, width, height)
 
         # The video publish is the result of a Batch render
-        if batch_render:
+        if is_batch_render:
             publish_name = preset_obj.get_batch_render_publish_name(path)
         else:
             publish_name = preset_obj.get_render_publish_name(path)


### PR DESCRIPTION
When a Shotgun submission is made from a Batch Render, the Shotgun
Integration cannot build a PublishedFile name (put ¨Unknown¨ as a name
instead of ¨Shot, segment_name¨)