### PR TITLE
Add support for Multi-Channel OpenEXR)

### DIFF
--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -104,7 +104,33 @@ class ExportSettings(HookBaseClass):
                       </resize>
                    </video>
                 """
-                
+        elif preset_name == "16 bit OpenEXR - Multi-Channel":
+            xml = """
+                   <video>
+                      <fileType>OpenEXR</fileType>
+                      <codec>596088</codec>
+                      <codecProfile></codecProfile>
+                      <namePattern>{VIDEO_NAME_PATTERN}</namePattern>
+                      <compressionQuality>50</compressionQuality>
+                      <transferCharacteristic>2</transferCharacteristic>
+                      <colorimetricSpecification>4</colorimetricSpecification>
+                      <multiTrack>True</multiTrack>
+                      <overwriteWithVersions>False</overwriteWithVersions>
+                      <resize>
+                         <resizeType>fit</resizeType>
+                         <resizeFilter>lanczos</resizeFilter>
+                         <width>0</width>
+                         <height>0</height>
+                         <bitsPerChannel>16</bitsPerChannel>
+                         <numChannels>3</numChannels>
+                         <floatingPoint>True</floatingPoint>
+                         <bigEndian>False</bigEndian>
+                         <pixelRatio>1</pixelRatio>
+                         <scanFormat>P</scanFormat>
+                      </resize>
+                   </video>
+
+                """
         else:
             raise TankError("Unknown video export preset '%s'!" % preset_name)
         

--- a/python/export_utils/export_preset.py
+++ b/python/export_utils/export_preset.py
@@ -555,7 +555,20 @@ class ExportPresetHandler(object):
         
         :returns: list of export preset strings 
         """
-        return self._export_presets.keys()
+        raw_preset_data = self._app.get_setting("plate_presets")
+
+        preset_names = []
+
+        for raw_preset in raw_preset_data:
+            preset_min_version = raw_preset.get("min_version", "0")
+
+            if sgtk.platform.current_engine().is_version_less_than(preset_min_version):
+                continue
+
+            preset_names.append(raw_preset["name"])
+
+        return sorted(preset_names)
+
 
     def get_preset_by_name(self, preset_name):
         """


### PR DESCRIPTION
This PR adds the 16 bits OpenEXR - Multi-Channel to the app.

This will require to have this added to the app config.
```
  - template: flame_shot_render_exr
    publish_type: Flame Render
    name: 16 bit OpenEXR - Multi-Channel
    upload_quicktime: true
    quicktime_publish_type: Flame Quicktime
    quicktime_template:
    batch_quicktime_template:
    batch_render_template: flame_shot_comp_exr
    start_frame: 100
    frame_handles: 10
    cut_type: '' 
    min_version: "2019.0"
```

I added a min_version entry to the preset setting to disallow a flame version lower than 2019 to have this preset on the UI since it would just crash!