### PR TITLE
Use Flame's in/out specified int he python hooks to define cut in/out

### DIFF
--- a/app.py
+++ b/app.py
@@ -434,10 +434,6 @@ class FlameExport(Application):
             if "handleOut" not in info:
                 info["handleOut"] = self._export_preset.get_handles_length()
 
-            # add start frame parameter to the flame chunk that we pass in
-            # to the segment
-            info["startFrame"] = self._export_preset.get_start_frame()
-
             # pass in raw data from flame
             segment.set_flame_data(info)
 

--- a/app.py
+++ b/app.py
@@ -48,6 +48,9 @@ from sgtk.platform import Application
 class FlameExport(Application):
     """
     Export functionality to automate and streamline content export out of Flame.
+
+    Details on Flame's data sent thru the exported hooks can be found at
+    https://knowledge.autodesk.com/search-result/caas/CloudHelp/cloudhelp/2017/ENU/Flame-API/files/GUID-8EE47B4F-16F0-41D6-97BB-1226C0BDCC45-htm.html
     """
 
     def init_app(self):

--- a/python/export_utils/segment.py
+++ b/python/export_utils/segment.py
@@ -18,6 +18,9 @@ class Segment(object):
     Represents a timeline segment in flame.
 
     Each timeline segment is parented under a shot.
+
+    Details on Flame's data sent thru the exported hooks can be found at
+    https://knowledge.autodesk.com/search-result/caas/CloudHelp/cloudhelp/2017/ENU/Flame-API/files/GUID-8EE47B4F-16F0-41D6-97BB-1226C0BDCC45-htm.html
     """
     def __init__(self, parent, name):
         """
@@ -175,7 +178,7 @@ class Segment(object):
     @property
     def edit_in_frame(self):
         """
-        Returns the in frame for the edit point
+        Returns the in frame timecode for the edit point
         This denotes where this segment sits in the sequence based timeline.
         """
         return self._get_flame_property("recordIn")
@@ -183,7 +186,7 @@ class Segment(object):
     @property
     def edit_out_frame(self):
         """
-        Returns the out frame for the edit point.
+        Returns the out frame timcode for the edit point.
         This denotes where this segment sits in the sequence based timeline.
         """
         return self._get_flame_property("recordOut") - 1

--- a/python/export_utils/segment.py
+++ b/python/export_utils/segment.py
@@ -186,7 +186,7 @@ class Segment(object):
         Returns the out frame for the edit point.
         This denotes where this segment sits in the sequence based timeline.
         """
-        return self._get_flame_property("recordOut")
+        return self._get_flame_property("recordOut") - 1
 
     @property
     def cut_in_frame(self):
@@ -199,7 +199,7 @@ class Segment(object):
         this value does not correspond to the value found in the original
         sequence data in flame.
         """
-        return self._get_flame_property("startFrame") + self._get_flame_property("handleIn")
+        return self._get_flame_property("sourceIn") + self._get_flame_property("handleIn")
 
     @property
     def cut_out_frame(self):
@@ -212,21 +212,21 @@ class Segment(object):
         this value does not correspond to the value found in the original
         sequence data in flame.
         """
-        return self._get_flame_property("startFrame") + self._get_flame_property("handleIn") + (self.edit_out_frame - self.edit_in_frame) -1
+        return self._get_flame_property("sourceOut") - self._get_flame_property("handleOut") - 1
 
     @property
     def head_in_frame(self):
         """
         Returns the in frame within the segment, including any handles.
         """
-        return self._get_flame_property("startFrame")
+        return self._get_flame_property("sourceIn")
 
     @property
     def tail_out_frame(self):
         """
         Returns the out frame within the segment, including any handles
         """
-        return self.cut_out_frame + self._get_flame_property("handleOut")
+        return self._get_flame_property("sourceOut") - 1
 
     @property
     def edit_in_timecode(self):


### PR DESCRIPTION
JIRA: SMOK-47960
In / Out / Duration informations are wrong for assets created by the Shotgun Flame Exporter.

Fixed edit_out_frame that was not considering that recordOut is exclusive in
Flame.

Fixed cut_in_frame, cut_out_frame, head_in_frame & tail_outFrame to use
sourceIn/sourceOut from Flame instead of startFrame from the preset.