### PR TITLE
Set proper minimum tk-core based on previous fixes

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -182,7 +182,7 @@ description: "Export Flame sequences to Shotgun and the file system."
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.18.148"
+requires_core_version: "v0.18.45"
 requires_engine_version: "v1.6.3"
 
 # the frameworks required to run this app


### PR DESCRIPTION
JIRA: SMOK-48559 SMOK-48675

Using "from PySide import x" requiere tk-core v0.18.45

I've upgraded the minimum to the latest by mistake in previous PR.