### PR TITLE
Use source timecode for frame numbering

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -126,11 +126,6 @@ configuration:
                     type: bool
                     default_value: true
 
-                start_frame:
-                    description: Start frame for created image sequences.
-                    type: int
-                    default_value: 100
-
                 frame_handles:
                     description: Length of handles to include as part of exported media.
                     type: int

--- a/python/export_utils/sequence.py
+++ b/python/export_utils/sequence.py
@@ -268,7 +268,7 @@ class Sequence(object):
                     # get the fps for the entire sequence by pulling it from
                     # the first segment
                     "fps": shots_in_cut_order[0].get_base_segment().sequence_fps,
-                    "duration": sum([shot.get_base_segment().duration for shot in self.shots]),
+                    "duration": sum([shot.get_base_segment().duration for shot in self.shots if shot.get_base_segment() is not None]),
                     "timecode_start_text": shots_in_cut_order[0].get_base_segment().edit_in_timecode,
                     "timecode_end_text": shots_in_cut_order[-1].get_base_segment().edit_out_timecode,
                 }


### PR DESCRIPTION
JIRA: SMOK-48846
Can have a mismatch between version and shot informations in Shotgun

Use source timecode for render simplify the handling of version and avoid having
to decide where to start counting. It also align with most user way of adding
handles before the start of version.