### PR TITLE
Add back code that fetch frame padding from template

### DIFF
--- a/app.py
+++ b/app.py
@@ -324,7 +324,9 @@ class FlameExport(Application):
             # handle the Flame sequence token - it will come in as "[1001-1100]"
             re_match = re.search(".*(\[[0-9]+-[0-9]+\])\..*", info["resolvedPath"])
             if re_match:
-                fields["SEQ"] = re_match.group(1)
+                frames = re_match.group(1)
+                fields["SEQ"] = frames
+                fields["timecode"] = frames
 
         # create some fields based on the info in the info params                
         if "versionNumber" in info:

--- a/app.py
+++ b/app.py
@@ -326,7 +326,7 @@ class FlameExport(Application):
             if re_match:
                 frames = re_match.group(1)
                 fields["SEQ"] = frames
-                fields["timecode"] = frames
+                fields["flame.frame"] = frames
 
         # create some fields based on the info in the info params                
         if "versionNumber" in info:

--- a/info.yml
+++ b/info.yml
@@ -132,7 +132,8 @@ configuration:
                     default_value: 10
 
                 #use_timecode_as_frame_number:
-                #    description: Use timecode frame numbering when exporting frame sequences (optional)
+                #    description: Use timecode frame numbering when exporting frame sequences
+                #                 (optional / commented out since default value do not populate on config upgrade)
                 #    type: bool
                 #    default_value: True
 

--- a/info.yml
+++ b/info.yml
@@ -81,7 +81,7 @@ configuration:
                 template:
                     description: Toolkit file system template to control where plate output goes on disk.
                     type: template
-                    fields: context, [SEQ], [timecode], Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
+                    fields: context, [SEQ], [flame.frame], Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
 
                 quicktime_template:
                     description: If not set to null, a higher res quicktime will be generated and stored on disk,
@@ -102,7 +102,7 @@ configuration:
                     type: template
                     allows_empty: True
                     default_value: null
-                    fields: context, [SEQ], [timecode], Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
+                    fields: context, [SEQ], [flame.frame], Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
 
 
                 batch_quicktime_template:
@@ -130,6 +130,11 @@ configuration:
                     description: Length of handles to include as part of exported media.
                     type: int
                     default_value: 10
+
+                use_timecode_as_frame_number:
+                    description: Use timecode frame numbering when exporting frame sequences
+                    type: bool
+                    default_value: True
 
     segment_clip_template:
         description: "Toolkit file system template to control where segment based clip files go on disk.

--- a/info.yml
+++ b/info.yml
@@ -81,7 +81,7 @@ configuration:
                 template:
                     description: Toolkit file system template to control where plate output goes on disk.
                     type: template
-                    fields: context, SEQ, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
+                    fields: context, [SEQ], [timecode], Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
 
                 quicktime_template:
                     description: If not set to null, a higher res quicktime will be generated and stored on disk,
@@ -102,7 +102,7 @@ configuration:
                     type: template
                     allows_empty: True
                     default_value: null
-                    fields: context, SEQ, Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
+                    fields: context, [SEQ], [timecode], Shot, version, segment_name, [YYYY], [MM], [DD], [hh], [mm], [ss], [width], [height], *
 
 
                 batch_quicktime_template:

--- a/info.yml
+++ b/info.yml
@@ -131,10 +131,10 @@ configuration:
                     type: int
                     default_value: 10
 
-                use_timecode_as_frame_number:
-                    description: Use timecode frame numbering when exporting frame sequences
-                    type: bool
-                    default_value: True
+                #use_timecode_as_frame_number:
+                #    description: Use timecode frame numbering when exporting frame sequences (optional)
+                #    type: bool
+                #    default_value: True
 
     segment_clip_template:
         description: "Toolkit file system template to control where segment based clip files go on disk.

--- a/python/export_utils/export_preset.py
+++ b/python/export_utils/export_preset.py
@@ -323,6 +323,7 @@ class ExportPreset(object):
                {VIDEO_EXPORT_PRESET}
 
                <name>
+                  <framePadding>{FRAME_PADDING}</framePadding>
                   <useTimecode>True</useTimecode>
                </name>
                <createOpenClip>
@@ -359,6 +360,19 @@ class ExportPreset(object):
 
         # now adjust some parameters in the export xml based on the template setup.
         template = self.get_render_template()
+        
+        # First up is the padding for sequences:        
+        sequence_key = template.keys["SEQ"]
+        
+        # The format spec is something like "04"
+        # strip off leading zeroes
+        # TODO: Flame defaults to zero-padded numbers (e.g. 001, 002, 003 instead of 1, 2, 3)
+        # raise an error in case someone tries to use a template which 
+        # does use non-zero padded token.
+        format_spec = sequence_key.format_spec.lstrip("0")        
+        xml = xml.replace("{FRAME_PADDING}", format_spec)
+        self._app.log_debug("Flame preset generation: Setting frame padding to %s based on "
+                            "SEQ token in template %s" % (format_spec, template))
 
         # Align the padding for versions with the definition in the version template
         version_key = template.keys["version"]

--- a/python/export_utils/export_preset.py
+++ b/python/export_utils/export_preset.py
@@ -374,19 +374,19 @@ class ExportPreset(object):
             return key.format_spec.lstrip("0")
 
         # First up is the padding for sequences
-        # (use timecode token first else fallback on SEQ)
-        frame_token = "timecode"
+        # (use flame.frame token first else fallback on SEQ for legacy configs)
+        frame_token = "flame.frame"
         sequence_key = template.keys.get(frame_token)
         if sequence_key is None:
             frame_token = "SEQ"
             sequence_key = template.keys.get(frame_token)
-        use_timecode = frame_token == "timecode"
 
         frame_padding = get_padding_from_key(key=sequence_key, default="4")
         xml = xml.replace("{FRAME_PADDING}", frame_padding)
         self._app.log_debug("Flame preset generation: Setting frame padding to %s based on "
                             "%s token in template %s" % (frame_padding, frame_token, template))
 
+        use_timecode = str(self._raw_preset["use_timecode_as_frame_number"])
         xml = xml.replace("{USE_TIMECODE}", str(use_timecode))
         self._app.log_debug("Flame preset generation: Setting use timecode to %s based on "
                             "%s token in template %s" % (use_timecode, frame_token, template))

--- a/python/export_utils/export_preset.py
+++ b/python/export_utils/export_preset.py
@@ -361,9 +361,6 @@ class ExportPreset(object):
         # now adjust some parameters in the export xml based on the template setup.
         template = self.get_render_template()
         
-        import pdb
-        pdb.set_trace()
-
         def get_padding_from_key(key, default):
             """
             Convert a key format spec into a padding that can be used in flame

--- a/python/export_utils/export_preset.py
+++ b/python/export_utils/export_preset.py
@@ -386,7 +386,7 @@ class ExportPreset(object):
         self._app.log_debug("Flame preset generation: Setting frame padding to %s based on "
                             "%s token in template %s" % (frame_padding, frame_token, template))
 
-        use_timecode = str(self._raw_preset["use_timecode_as_frame_number"])
+        use_timecode = str(self._raw_preset.get("use_timecode_as_frame_number", True))
         xml = xml.replace("{USE_TIMECODE}", str(use_timecode))
         self._app.log_debug("Flame preset generation: Setting use timecode to %s based on "
                             "%s token in template %s" % (use_timecode, frame_token, template))

--- a/python/export_utils/export_preset.py
+++ b/python/export_utils/export_preset.py
@@ -393,7 +393,7 @@ class ExportPreset(object):
 
         # Align the padding for versions with the definition in the version template
         version_key = template.keys.get("version")
-        vesion_padding = get_padding_from_key(key=sequence_key, default="3")
+        vesion_padding = get_padding_from_key(key=version_key, default="3")
         xml = xml.replace("{VERSION_PADDING}", vesion_padding)
         self._app.log_debug("Flame preset generation: Setting version padding to %s based on "
                             "version token in template %s" % (vesion_padding, template))

--- a/python/export_utils/export_preset.py
+++ b/python/export_utils/export_preset.py
@@ -324,7 +324,7 @@ class ExportPreset(object):
 
                <name>
                   <framePadding>{FRAME_PADDING}</framePadding>
-                  <useTimecode>True</useTimecode>
+                  <useTimecode>{USE_TIMECODE}</useTimecode>
                </name>
                <createOpenClip>
                   <namePattern>{SEGMENT_CLIP_NAME_PATTERN}</namePattern>
@@ -361,29 +361,45 @@ class ExportPreset(object):
         # now adjust some parameters in the export xml based on the template setup.
         template = self.get_render_template()
         
-        # First up is the padding for sequences:        
-        sequence_key = template.keys["SEQ"]
-        
-        # The format spec is something like "04"
-        # strip off leading zeroes
-        # TODO: Flame defaults to zero-padded numbers (e.g. 001, 002, 003 instead of 1, 2, 3)
-        # raise an error in case someone tries to use a template which 
-        # does use non-zero padded token.
-        format_spec = sequence_key.format_spec.lstrip("0")        
-        xml = xml.replace("{FRAME_PADDING}", format_spec)
+        import pdb
+        pdb.set_trace()
+
+        def get_padding_from_key(key, default):
+            """
+            Convert a key format spec into a padding that can be used in flame
+            export preset.  The format spec is something like "04" for 0
+            prefixed 4 digit padding.
+            """
+            if key is None:
+                return str(default)
+            if key.format_spec[0] != "0":
+                return "1"
+            return key.format_spec.lstrip("0")
+
+        # First up is the padding for sequences
+        # (use timecode token first else fallback on SEQ)
+        frame_token = "timecode"
+        sequence_key = template.keys.get(frame_token)
+        if sequence_key is None:
+            frame_token = "SEQ"
+            sequence_key = template.keys.get(frame_token)
+        use_timecode = frame_token == "timecode"
+
+        frame_padding = get_padding_from_key(key=sequence_key, default="4")
+        xml = xml.replace("{FRAME_PADDING}", frame_padding)
         self._app.log_debug("Flame preset generation: Setting frame padding to %s based on "
-                            "SEQ token in template %s" % (format_spec, template))
+                            "%s token in template %s" % (frame_padding, frame_token, template))
+
+        xml = xml.replace("{USE_TIMECODE}", str(use_timecode))
+        self._app.log_debug("Flame preset generation: Setting use timecode to %s based on "
+                            "%s token in template %s" % (use_timecode, frame_token, template))
 
         # Align the padding for versions with the definition in the version template
-        version_key = template.keys["version"]
-        # the format spec is something like "03"
-        # TODO: Flame defaults to zero-padded numbers (e.g. 001, 002, 003 instead of 1, 2, 3)
-        # raise an error in case someone tries to use a template which 
-        # does use non-zero padded token.
-        format_spec = version_key.format_spec.lstrip("0")
-        xml = xml.replace("{VERSION_PADDING}", format_spec)        
+        version_key = template.keys.get("version")
+        vesion_padding = get_padding_from_key(key=sequence_key, default="3")
+        xml = xml.replace("{VERSION_PADDING}", vesion_padding)
         self._app.log_debug("Flame preset generation: Setting version padding to %s based on "
-                            "version token in template %s" % (format_spec, template))
+                            "version token in template %s" % (vesion_padding, template))
 
         # write it to disk
         preset_path = self.__write_content_to_file(xml, "export_preset.xml")

--- a/python/export_utils/shotgun_submit.py
+++ b/python/export_utils/shotgun_submit.py
@@ -608,7 +608,7 @@ class ShotgunSubmitter(object):
         
         fields = template.get_fields(flame_path)
         fields["SEQ"] = "FORMAT: %d"
-        fields["timecode"] = "FORMAT: %d"
+        fields["flame.frame"] = "FORMAT: %d"
         return template.apply_fields(fields)
 
     def __extract_thumbnail(self, path, width, height):

--- a/python/export_utils/shotgun_submit.py
+++ b/python/export_utils/shotgun_submit.py
@@ -606,9 +606,10 @@ class ShotgunSubmitter(object):
                             "This sometimes happens if Flame sequences or clips contain special characters "
                             "such as slashes or spaces." % flame_path)
         
-        fields = template.get_fields(flame_path)    
+        fields = template.get_fields(flame_path)
         fields["SEQ"] = "FORMAT: %d"
-        return template.apply_fields(fields)        
+        fields["timecode"] = "FORMAT: %d"
+        return template.apply_fields(fields)
 
     def __extract_thumbnail(self, path, width, height):
         """


### PR DESCRIPTION
JIRA: SMOK-49006
Getting invalid padding for Flame published file path

I've removed that code thinking it did not apply to file numbered using timecode
but it does. Ideally, the template we should use should have 8 digits wide since
this is the default in Flame.