### PR TITLE
Add setting to suppress warnings for empty shot names

### DIFF
--- a/app.py
+++ b/app.py
@@ -287,13 +287,14 @@ class FlameExport(Application):
         # check that the clip has a shot name - otherwise things won't work!
         if shot_name == "":       
             from sgtk.platform.qt import QtGui
-            QtGui.QMessageBox.warning(
-                None,
-                "Missing shot name!",
-                ("The clip '%s' does not have a shot name and therefore cannot be exported. "
-                 "Please ensure that all shots you wish to exports "
-                 "have been named. " % asset_name)
-            )
+            if not self.get_setting("allow_empty_shot_names"):
+                QtGui.QMessageBox.warning(
+                    None,
+                    "Missing shot name!",
+                    ("The clip '%s' does not have a shot name and therefore cannot be exported. "
+                     "Please ensure that all shots you wish to export "
+                     "have been named. " % asset_name)
+                )
             
             # TODO: send the clip to the trash for now. no way to abort at this point
             # but we don't have enough information to be able to proceed at this point either
@@ -423,7 +424,11 @@ class FlameExport(Application):
         if asset_type not in ["video", 'movie', "batch"]:
             # ignore anything that isn't video or batch
             return
-        
+
+        if shot_name == "" and self.get_setting("allow_empty_shot_names"):
+            # continue more gracefully
+            return
+
         # resolve shot object
         shot = self._sequences[-1].get_shot(shot_name)
 

--- a/info.yml
+++ b/info.yml
@@ -168,6 +168,11 @@ configuration:
         description: The publish type for Flame batch scripts
         default_value: "Flame Batch File"
 
+    allow_empty_shot_names:
+        description: If a sequence has at least one segment with a Shot name, ignore any other segments without a shot
+                     name more gracefully.
+        type: bool
+        default_value: false
 
 
 # this app works in all engines - it does not contain


### PR DESCRIPTION
In CBS Digital's case, many segments in the timeline are non-VFX reference clips and we do not want to create Shots in Shotgun or folders on disk for them. Adding an option to `allow_empty_shot_names` would prevent conform artists from having to click through a zillion warnings and tracebacks on export.

As far as I can see, no other functionality inside of flame is actually impacted. I'm not sure what the effect would be when using Shotgun Review or RV, but we will be using the conformed timelines in Flame for review.